### PR TITLE
130 complete language consistency throughout the application

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,14 @@ symfony server:start
 - Passwords are handled by Symfony’s **Security** component.
 - `symfony/serializer` is installed to expose entities as JSON (e.g. for an Angular frontend).
 
+### API locale (Angular ↔ Symfony)
+
+For routes under `/api/`, `App\EventSubscriber\ApiLocaleSubscriber` sets `Request::locale` from the **`Accept-Language`** header (or from query **`?locale=`** as an override). Supported codes: **`ca`**, **`es`**, **`en`**, **`fr`**, aligned with the Angular app (`ngx-translate` + `LanguageService`).
+
+- Symfony: `src/EventSubscriber/ApiLocaleSubscriber.php`, translations `translations/api.{ca,es,en,fr}.yaml` (domain `api`), config `config/packages/translation.yaml`.
+- Angular (sibling repo **FalconCare**): sends the header via `src/app/interceptors/locale.interceptor.ts` (see `src/app/app.config.ts`).
+- Contract test: `tests/Controller/Api/ApiAcceptLanguageTest.php`.
+
 ### REST `/api/patients` (Angular / Neon)
 
 - Base path: `/api` (e.g. dev `http://127.0.0.1:8000/api/patients`). JWT Bearer on protected routes.

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -54,7 +54,10 @@ security:
         - { path: ^/api/auth/login, roles: PUBLIC_ACCESS }
         - { path: ^/api/auth/register-doctor, roles: PUBLIC_ACCESS }
         - { path: ^/api/health, roles: PUBLIC_ACCESS }
-        - { path: ^/api/users, roles: ROLE_ADMIN }
+        # /api/users: listar y crear solo admin; borrar solo admin; GET/PUT/PATCH /api/users/{id} autenticados (el controlador restringe al propio usuario o admin).
+        - { path: ^/api/users$, roles: ROLE_ADMIN, methods: [GET, POST] }
+        - { path: '^/api/users/\d+$', roles: ROLE_ADMIN, methods: [DELETE] }
+        - { path: '^/api/users/\d+$', roles: IS_AUTHENTICATED_FULLY, methods: [GET, PUT, PATCH] }
         - { path: ^/api, roles: IS_AUTHENTICATED_FULLY }
         # - { path: ^/admin, roles: ROLE_ADMIN }
         # - { path: ^/profile, roles: ROLE_USER }

--- a/config/packages/translation.yaml
+++ b/config/packages/translation.yaml
@@ -1,5 +1,6 @@
 framework:
-    default_locale: en
+    default_locale: es
+    enabled_locales: ['ca', 'es', 'en', 'fr']
     translator:
         default_path: '%kernel.project_dir%/translations'
-        providers:
+        fallbacks: ['es', 'en']

--- a/scripts/check-api-translations.php
+++ b/scripts/check-api-translations.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * @param array<string, mixed> $a
+ * @return array<string, true>
+ */
+function flatten(array $a, string $p = ''): array
+{
+    $o = [];
+    foreach ($a as $k => $v) {
+        $nk = $p === '' ? (string) $k : $p.'.'.$k;
+        if (\is_array($v) && !array_is_list($v)) {
+            $o += flatten($v, $nk);
+        } else {
+            $o[$nk] = true;
+        }
+    }
+
+    return $o;
+}
+
+$base = dirname(__DIR__) . '/translations';
+$langs = ['ca', 'es', 'en', 'fr'];
+$sets = [];
+foreach ($langs as $L) {
+    $path = $base . '/api.'.$L.'.yaml';
+    $sets[$L] = array_keys(flatten(Yaml::parseFile($path)));
+}
+
+$all = [];
+foreach ($langs as $L) {
+    $all = array_merge($all, $sets[$L]);
+}
+$all = array_values(array_unique($all));
+sort($all);
+
+$failed = false;
+foreach ($langs as $L) {
+    $miss = array_values(array_diff($all, $sets[$L]));
+    if ($miss !== []) {
+        $failed = true;
+        fwrite(STDERR, "[$L] missing ".count($miss)." keys\n");
+        foreach (array_slice($miss, 0, 30) as $m) {
+            fwrite(STDERR, "  - $m\n");
+        }
+    }
+}
+
+if ($failed) {
+    exit(1);
+}
+
+echo 'api.*.yaml: '.count($all)." keys aligned for ".implode(', ', $langs)."\n";

--- a/scripts/verify-api-i18n-parity.php
+++ b/scripts/verify-api-i18n-parity.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Comprueba que translations/api.{ca,es,en,fr}.yaml tengan las mismas claves anidadas.
+ * Uso: php scripts/verify-api-i18n-parity.php
+ */
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+use Symfony\Component\Yaml\Yaml;
+
+/** @return array<string, string> */
+function flattenYaml(array $node, string $prefix = ''): array
+{
+    $out = [];
+    foreach ($node as $key => $value) {
+        $path = $prefix === '' ? (string) $key : $prefix . '.' . $key;
+        if (\is_array($value) && [] !== $value && !array_is_list($value)) {
+            $out += flattenYaml($value, $path);
+        } else {
+            $out[$path] = \is_scalar($value) ? (string) $value : json_encode($value);
+        }
+    }
+
+    return $out;
+}
+
+$langs = ['ca', 'es', 'en', 'fr'];
+$base = dirname(__DIR__) . '/translations';
+$data = [];
+foreach ($langs as $lang) {
+    $path = $base . '/api.' . $lang . '.yaml';
+    if (!is_file($path)) {
+        fwrite(STDERR, "Falta archivo: {$path}\n");
+        exit(1);
+    }
+    $parsed = Yaml::parseFile($path);
+    if (!\is_array($parsed)) {
+        fwrite(STDERR, "YAML inválido: {$path}\n");
+        exit(1);
+    }
+    $data[$lang] = flattenYaml($parsed);
+}
+
+$allKeys = [];
+foreach ($langs as $lang) {
+    $allKeys = array_merge($allKeys, array_keys($data[$lang]));
+}
+$allKeys = array_values(array_unique($allKeys));
+sort($allKeys);
+
+$exit = 0;
+foreach ($langs as $lang) {
+    $missing = [];
+    foreach ($allKeys as $k) {
+        if (!\array_key_exists($k, $data[$lang])) {
+            $missing[] = $k;
+        }
+    }
+    if ($missing !== []) {
+        fwrite(STDERR, "api.{$lang}.yaml faltan " . \count($missing) . " claves (ej.): " . implode(', ', \array_slice($missing, 0, 15)) . "\n");
+        $exit = 1;
+    }
+}
+
+if ($exit === 0) {
+    echo 'api.*.yaml: OK, ' . \count($allKeys) . " claves aplanadas en 4 idiomas.\n";
+}
+
+exit($exit);

--- a/src/Controller/Api/AppointmentController.php
+++ b/src/Controller/Api/AppointmentController.php
@@ -2,22 +2,26 @@
 
 namespace App\Controller\Api;
 
+use App\Controller\Api\Concerns\ApiTranslatorTrait;
 use App\Entity\Appointment;
 use App\Entity\Patient;
 use App\Form\AppointmentType;
 use App\Repository\AppointmentRepository;
 use App\Entity\Odontogram;
+use App\Service\AppointmentListSerializer;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 
 #[Route('/api/appointment')]
 final class AppointmentController extends AbstractController
 {
+    use ApiTranslatorTrait;
     private const STATUS_SCHEDULED = 'Programada';
     private const STATUS_MISSING_CONSENT = 'Falta consentiment';
     private const STATUS_IN_PROGRESS = 'En curs';
@@ -41,20 +45,10 @@ final class AppointmentController extends AbstractController
     private const ALLOWED_CLEANING_MINUTES = [5, 10, 15];
     private const NO_KNOWN_MEDICATION_ALLERGIES = 'Cap coneguda';
 
-    private function normalizeAppointmentStatus(?string $status): string
-    {
-        $status = trim((string) $status);
-
-        if ($status === '') {
-            return self::STATUS_SCHEDULED;
-        }
-
-        return match ($status) {
-            'Encurs' => self::STATUS_IN_PROGRESS,
-            'Falta Consentiment' => self::STATUS_MISSING_CONSENT,
-            'Cancel·lada', 'CancelÂ·lada' => 'Cancelada',
-            default => $status,
-        };
+    public function __construct(
+        private readonly AppointmentListSerializer $appointmentListSerializer,
+        private readonly TranslatorInterface $translator,
+    ) {
     }
 
     #[Route('/index', name: 'app_appointment_index', methods: ['GET'])]
@@ -65,55 +59,7 @@ final class AppointmentController extends AbstractController
 
         $appointments = $repo->findByDate($fecha);
 
-        return $this->json($this->serializeAppointments($appointments));
-    }
-
-    private function serializeAppointments(array $appointments): array
-        {
-        $result = [];
-        foreach ($appointments as $appointment) {
-            $reason = $appointment->getConsultationReason() ?? '';
-            $status = $this->normalizeAppointmentStatus($appointment->getStatus());
-            
-            $isUrgency = $appointment->isUrgency() || str_contains(strtolower($reason), 'urgència') || str_contains(strtolower($reason), 'urgencia');
-            $isFirstVisit = $appointment->isFirstVisit() || str_contains(strtolower($reason), 'primera visita');
-
-            if ($status === 'Finalitzada') {
-                $color = '#9e9e9e';
-            } elseif ($isUrgency) {
-                $color = '#e91e63';
-            } elseif ($isFirstVisit) {
-                $color = '#9c27b0';
-            } else {
-                $color = '#00bcd4';
-            }
-
-            $result[] = [
-                'id' => $appointment->getId(),
-                'date' => $appointment->getVisitDate()->format('Y-m-d'),
-                'time' => $appointment->getVisitTime() ? $appointment->getVisitTime()->format('H:i') : '--:--',
-                'duration' => $appointment->getDurationMinutes() ?? 30,
-                'cleaningTime' => $appointment->getCleaningMinutes(),
-                'cleaning_time' => $appointment->getCleaningMinutes(),
-                'cleaningMinutes' => $appointment->getCleaningMinutes(),
-                'totalBlockTime' => $appointment->getTotalDurationWithCleaning(),
-                'patientName' => $appointment->getPatient() 
-                    ? $appointment->getPatient()->getFirstName() . ' ' . $appointment->getPatient()->getLastName() 
-                    : 'Sense Pacient',
-                'doctorName' => $appointment->getDoctor() 
-                    ? trim($appointment->getDoctor()->getFirstName() . ' ' . $appointment->getDoctor()->getLastNames())
-                    : 'Sense Doctor',
-                'doctorId' => $appointment->getDoctor() ? $appointment->getDoctor()->getId() : null,
-                'boxId' => $appointment->getBox() ? $appointment->getBox()->getId() : null,
-                'box' => $appointment->getBox() ? $appointment->getBox()->getBoxName() : 'Sense Box',
-                'reason' => $reason,
-                'status' => $status,
-                'color' => $color,
-                'isUrgency' => $isUrgency,
-                'isFirstVisit' => $isFirstVisit
-            ];
-        }
-        return $result;
+        return $this->json($this->appointmentListSerializer->serializeList($appointments));
     }
 
     #[Route('/weekly', name: 'app_appointment_weekly', methods: ['GET'])]
@@ -135,7 +81,7 @@ final class AppointmentController extends AbstractController
             ], Response::HTTP_BAD_REQUEST);
         }
 
-        return $this->json($this->serializeAppointments($appointments));
+        return $this->json($this->appointmentListSerializer->serializeList($appointments));
     }
 
     #[Route('/statuses', name: 'app_appointment_statuses', methods: ['GET'])]
@@ -232,7 +178,7 @@ final class AppointmentController extends AbstractController
         $doctor = $appointment->getDoctor();
         $box = $appointment->getBox();
         $reason = $appointment->getConsultationReason() ?? '';
-        $status = $this->normalizeAppointmentStatus($appointment->getStatus());
+        $status = $this->appointmentListSerializer->normalizeStatus($appointment->getStatus());
 
         $data = [
             'id' => $appointment->getId(),
@@ -395,7 +341,7 @@ final class AppointmentController extends AbstractController
                         'code' => 'DOCTOR_OCCUPIED',
                         'error' => [
                             'messageKey' => 'appointment.doctor.occupied',
-                            'message' => 'El doctor ya tiene una cita en ese horario.',
+                            'message' => $this->apiTrans('APPOINTMENT_DOCTOR_SLOT_CONFLICT'),
                         ],
                     ], Response::HTTP_CONFLICT);
                 }
@@ -408,7 +354,7 @@ final class AppointmentController extends AbstractController
                     'code' => 'APPOINTMENT_CREATED',
                     'messageKey' => 'appointment.created',
                     'id' => $appointment->getId(),
-                    'status' => $this->normalizeAppointmentStatus($appointment->getStatus()),
+                    'status' => $this->appointmentListSerializer->normalizeStatus($appointment->getStatus()),
                     'appointment' => $this->serializeAppointment($appointment),
                 ];
 
@@ -480,7 +426,7 @@ final class AppointmentController extends AbstractController
             'code' => 'APPOINTMENT_OPENED',
             'messageKey' => 'appointment.opened',
             'id' => $appointment->getId(),
-            'status' => $this->normalizeAppointmentStatus($appointment->getStatus()),
+            'status' => $this->appointmentListSerializer->normalizeStatus($appointment->getStatus()),
             'odontogramId' => $odontogramId,
             'appointment' => $this->serializeAppointment($appointment, $odontogramId),
         ]);
@@ -503,7 +449,7 @@ final class AppointmentController extends AbstractController
             'code' => 'APPOINTMENT_CLOSED',
             'messageKey' => 'appointment.closed',
             'id' => $appointment->getId(),
-            'status' => $this->normalizeAppointmentStatus($appointment->getStatus()),
+            'status' => $this->appointmentListSerializer->normalizeStatus($appointment->getStatus()),
             'appointment' => $this->serializeAppointment($appointment),
         ]);
     }
@@ -574,7 +520,7 @@ final class AppointmentController extends AbstractController
             'code' => 'APPOINTMENT_STATUS_UPDATED',
             'messageKey' => 'appointment.status.updated',
             'id' => $appointment->getId(),
-            'status' => $this->normalizeAppointmentStatus($appointment->getStatus()),
+            'status' => $this->appointmentListSerializer->normalizeStatus($appointment->getStatus()),
             'appointment' => $this->serializeAppointment($appointment),
         ]);
     }
@@ -641,7 +587,7 @@ final class AppointmentController extends AbstractController
                         'code' => 'DOCTOR_OCCUPIED',
                         'error' => [
                             'messageKey' => 'appointment.doctor.occupied',
-                            'message' => 'El doctor ya tiene una cita en ese horario.',
+                            'message' => $this->apiTrans('APPOINTMENT_DOCTOR_SLOT_CONFLICT'),
                         ],
                     ], Response::HTTP_CONFLICT);
                 }
@@ -653,7 +599,7 @@ final class AppointmentController extends AbstractController
                     'code' => 'APPOINTMENT_UPDATED',
                     'messageKey' => 'appointment.updated',
                     'id' => $appointment->getId(),
-                    'status' => $this->normalizeAppointmentStatus($appointment->getStatus()),
+                    'status' => $this->appointmentListSerializer->normalizeStatus($appointment->getStatus()),
                     'appointment' => $this->serializeAppointment($appointment),
                 ]);
             } catch (\Exception $e) {

--- a/src/Controller/Api/AuthController.php
+++ b/src/Controller/Api/AuthController.php
@@ -2,6 +2,7 @@
 
 namespace App\Controller\Api;
 
+use App\Controller\Api\Concerns\ApiTranslatorTrait;
 use App\Entity\Doctor;
 use App\Entity\User;
 use App\Repository\DoctorRepository;
@@ -15,17 +16,21 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 #[Route('/api/auth')]
 #[OA\Tag(name: 'Auth')]
 final class AuthController extends AbstractController
 {
+    use ApiTranslatorTrait;
+
     public function __construct(
         private readonly UserRepository $userRepository,
         private readonly DoctorRepository $doctorRepository,
         private readonly UserPasswordHasherInterface $passwordHasher,
         private readonly JwtTokenManager $jwtTokenManager,
         private readonly EntityManagerInterface $entityManager,
+        private readonly TranslatorInterface $translator,
     ) {
     }
 
@@ -79,10 +84,10 @@ final class AuthController extends AbstractController
 
         if ($email === '' || $password === '') {
             return $this->json([
-                'error' => 'Validation failed',
+                'error' => $this->apiTrans('AUTH_VALIDATION_FAILED'),
                 'errors' => [
-                    ['field' => 'email', 'message' => 'This value should not be blank.'],
-                    ['field' => 'password', 'message' => 'This value should not be blank.'],
+                    ['field' => 'email', 'message' => $this->apiTrans('AUTH_FIELD_BLANK')],
+                    ['field' => 'password', 'message' => $this->apiTrans('AUTH_FIELD_BLANK')],
                 ],
             ], Response::HTTP_UNPROCESSABLE_ENTITY);
         }
@@ -90,11 +95,11 @@ final class AuthController extends AbstractController
         /** @var User|null $user */
         $user = $this->userRepository->findOneByEmailCaseInsensitive($email);
         if (!$user) {
-            return $this->json(['error' => 'Invalid credentials'], Response::HTTP_UNAUTHORIZED);
+            return $this->json(['error' => $this->apiTrans('AUTH_INVALID_CREDENTIALS')], Response::HTTP_UNAUTHORIZED);
         }
 
         if (!$this->passwordHasher->isPasswordValid($user, $password)) {
-            return $this->json(['error' => 'Invalid credentials'], Response::HTTP_UNAUTHORIZED);
+            return $this->json(['error' => $this->apiTrans('AUTH_INVALID_CREDENTIALS')], Response::HTTP_UNAUTHORIZED);
         }
 
         $token = $this->jwtTokenManager->createToken($user);
@@ -122,31 +127,31 @@ final class AuthController extends AbstractController
 
         if ($fullName === '' || $email === '' || $password === '') {
             return $this->json([
-                'error' => 'Validation failed',
-                'message' => 'fullName, email and password are required.',
+                'error' => $this->apiTrans('AUTH_VALIDATION_FAILED'),
+                'message' => $this->apiTrans('AUTH_REGISTER_FIELDS_REQUIRED'),
             ], Response::HTTP_BAD_REQUEST);
         }
 
         if (mb_strlen($password) < 8) {
             return $this->json([
-                'error' => 'Validation failed',
-                'message' => 'Password must be at least 8 characters.',
+                'error' => $this->apiTrans('AUTH_VALIDATION_FAILED'),
+                'message' => $this->apiTrans('AUTH_PASSWORD_MIN_LENGTH'),
             ], Response::HTTP_BAD_REQUEST);
         }
 
         $normalizedEmail = mb_strtolower($email);
         if ($this->userRepository->findOneByEmailCaseInsensitive($normalizedEmail)) {
             return $this->json([
-                'error' => 'Validation failed',
-                'message' => 'Email already registered.',
+                'error' => $this->apiTrans('AUTH_VALIDATION_FAILED'),
+                'message' => $this->apiTrans('EMAIL_ALREADY_REGISTERED'),
             ], Response::HTTP_BAD_REQUEST);
         }
 
         $nameParts = preg_split('/\s+/', $fullName) ?: [];
         if (count($nameParts) < 2) {
             return $this->json([
-                'error' => 'Validation failed',
-                'message' => 'Full name must include name and surname.',
+                'error' => $this->apiTrans('AUTH_VALIDATION_FAILED'),
+                'message' => $this->apiTrans('AUTH_FULL_NAME_REQUIRES_SURNAME'),
             ], Response::HTTP_BAD_REQUEST);
         }
 
@@ -181,7 +186,7 @@ final class AuthController extends AbstractController
     {
         $user = $this->getUser();
         if (!$user instanceof User) {
-            return $this->json(['error' => 'Unauthorized'], Response::HTTP_UNAUTHORIZED);
+            return $this->json(['error' => $this->apiTrans('AUTH_UNAUTHORIZED')], Response::HTTP_UNAUTHORIZED);
         }
 
         $doctor = $this->doctorRepository->findOneBy(['email' => $user->getUserIdentifier()]);

--- a/src/Controller/Api/Concerns/ApiTranslatorTrait.php
+++ b/src/Controller/Api/Concerns/ApiTranslatorTrait.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Api\Concerns;
+
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * Traducciones dominio {@see TranslatorInterface} `api` (claves `error.*`, `http.*`).
+ * Requiere propiedad {@see TranslatorInterface} $translator en la clase que use el trait.
+ *
+ * @property-read TranslatorInterface $translator
+ */
+trait ApiTranslatorTrait
+{
+    protected function apiTrans(string $errorKey, array $parameters = []): string
+    {
+        return $this->translator->trans('error.'.$errorKey, $parameters, 'api');
+    }
+
+    protected function apiHttpLine(int $status): string
+    {
+        $key = 'http.'.$status;
+        $label = $this->translator->trans($key, [], 'api');
+
+        return $label !== $key ? $label : (Response::$statusTexts[$status] ?? 'Error');
+    }
+}

--- a/src/Controller/Api/DocumentApiController.php
+++ b/src/Controller/Api/DocumentApiController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Controller\Api;
 
+use App\Controller\Api\Concerns\ApiTranslatorTrait;
 use App\Entity\Patient;
 use App\Repository\DocumentRepository;
 use App\Repository\PatientRepository;
@@ -21,11 +22,14 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 #[Route('/api/documents')]
 #[OA\Tag(name: 'Documents')]
 final class DocumentApiController extends AbstractController
 {
+    use ApiTranslatorTrait;
+
     /** @var list<string> */
     private const ALLOWED_MIME_TYPES = [
         'application/pdf',
@@ -57,6 +61,7 @@ final class DocumentApiController extends AbstractController
         private readonly DocumentRepository $documentRepository,
         private readonly PatientRecordsAccessChecker $patientRecordsAccess,
         private readonly DocumentPatientAccessGuard $documentPatientAccess,
+        private readonly TranslatorInterface $translator,
         #[Autowire('%env(API_BASE_URL)%')]
         private readonly string $apiBaseUrl,
         #[Autowire('%env(int:DOCUMENT_MAX_UPLOAD_BYTES)%')]
@@ -89,27 +94,23 @@ final class DocumentApiController extends AbstractController
 
         $patientId = $this->resolvePatientFilterFromQuery($request);
         if ($patientId === null) {
-            return $this->apiError(
-                Response::HTTP_BAD_REQUEST,
-                'DOCUMENT_PATIENT_FILTER_REQUIRED',
-                'Provide patientId, patient.id, patient_id, patient[id], or patient (IRI), same as GET /api/documents.'
-            );
+            return $this->apiError(Response::HTTP_BAD_REQUEST, 'DOCUMENT_PATIENT_FILTER_REQUIRED');
         }
 
         $patient = $patientRepository->findById($patientId);
         if (!$patient) {
-            return $this->apiError(Response::HTTP_NOT_FOUND, 'PATIENT_NOT_FOUND', 'Patient not found');
+            return $this->apiError(Response::HTTP_NOT_FOUND, 'PATIENT_NOT_FOUND');
         }
 
         $dateString = $request->query->get('date');
         if (!$dateString) {
-            return $this->apiError(Response::HTTP_BAD_REQUEST, 'DATE_REQUIRED', 'Date parameter is required');
+            return $this->apiError(Response::HTTP_BAD_REQUEST, 'DATE_REQUIRED');
         }
 
         try {
             $date = new \DateTime((string) $dateString);
         } catch (\Exception) {
-            return $this->apiError(Response::HTTP_BAD_REQUEST, 'INVALID_DATE', 'Invalid date format. Use Y-m-d');
+            return $this->apiError(Response::HTTP_BAD_REQUEST, 'INVALID_DATE');
         }
 
         $page = max(1, (int) $request->query->get('page', '1'));
@@ -143,7 +144,7 @@ final class DocumentApiController extends AbstractController
 
         $patients = $patientRepository->findByIdentityDocument($identityDocument);
         if ($patients === []) {
-            return $this->apiError(Response::HTTP_NOT_FOUND, 'PATIENT_NOT_FOUND', 'Patient not found');
+            return $this->apiError(Response::HTTP_NOT_FOUND, 'PATIENT_NOT_FOUND');
         }
 
         $patient = $patients[0];
@@ -184,21 +185,17 @@ final class DocumentApiController extends AbstractController
 
         $patientId = PatientIriParser::parsePatientId($request->query->get('patientId'));
         if ($patientId === null) {
-            return $this->apiError(
-                Response::HTTP_BAD_REQUEST,
-                'DOCUMENT_PATIENT_ID_REQUIRED',
-                'Query parameter patientId is required and must match the document\'s patient.'
-            );
+            return $this->apiError(Response::HTTP_BAD_REQUEST, 'DOCUMENT_PATIENT_ID_REQUIRED');
         }
 
         $document = $this->documentRepository->findById($id);
         if ($err = $this->documentPatientAccess->validateDocumentOwnership($document, $patientId)) {
-            return $this->apiError($err['status'], $err['code'], $err['message']);
+            return $this->apiError($err['status'], $err['code']);
         }
 
         $filePath = $this->getParameter('kernel.project_dir') . '/public/uploads/documents/' . $document->getFilePath();
         if (!is_file($filePath)) {
-            return $this->apiError(Response::HTTP_NOT_FOUND, 'DOCUMENT_FILE_NOT_FOUND', 'File not found on server');
+            return $this->apiError(Response::HTTP_NOT_FOUND, 'DOCUMENT_FILE_NOT_FOUND');
         }
 
         $downloadName = $document->getOriginalName() ?? $document->getFilePath();
@@ -236,11 +233,7 @@ final class DocumentApiController extends AbstractController
 
         $patientId = $this->resolvePatientFilterFromQuery($request);
         if ($patientId === null) {
-            return $this->apiError(
-                Response::HTTP_BAD_REQUEST,
-                'DOCUMENT_PATIENT_FILTER_REQUIRED',
-                'Provide patientId, patient.id, patient_id, patient[id], or patient (IRI) to list documents. Global listing is disabled.'
-            );
+            return $this->apiError(Response::HTTP_BAD_REQUEST, 'DOCUMENT_PATIENT_FILTER_REQUIRED');
         }
 
         return $this->jsonDocumentsForPatientId($request, $patientId, $patientRepository);
@@ -282,23 +275,19 @@ final class DocumentApiController extends AbstractController
 
         $uploadedFile = $request->files->get('file');
         if (!$uploadedFile instanceof UploadedFile) {
-            return $this->apiError(Response::HTTP_BAD_REQUEST, 'DOCUMENT_FILE_REQUIRED', 'No file provided');
+            return $this->apiError(Response::HTTP_BAD_REQUEST, 'DOCUMENT_FILE_REQUIRED');
         }
 
         if (\UPLOAD_ERR_INI_SIZE === $uploadedFile->getError() || \UPLOAD_ERR_FORM_SIZE === $uploadedFile->getError()) {
-            return $this->apiError(Response::HTTP_REQUEST_ENTITY_TOO_LARGE, 'DOCUMENT_FILE_TOO_LARGE', 'Uploaded file exceeds size limit.');
+            return $this->apiError(Response::HTTP_REQUEST_ENTITY_TOO_LARGE, 'DOCUMENT_FILE_TOO_LARGE');
         }
         if ($uploadedFile->getError() !== \UPLOAD_ERR_OK) {
-            return $this->apiError(Response::HTTP_BAD_REQUEST, 'DOCUMENT_FILE_UPLOAD_ERROR', 'Upload error detected.');
+            return $this->apiError(Response::HTTP_BAD_REQUEST, 'DOCUMENT_FILE_UPLOAD_ERROR');
         }
 
         $patientRaw = $request->request->get('patient');
         if (!\is_string($patientRaw) || trim($patientRaw) === '') {
-            return $this->apiError(
-                Response::HTTP_BAD_REQUEST,
-                'DOCUMENT_PATIENT_REQUIRED',
-                'Field "patient" is required and must be the absolute patient IRI.'
-            );
+            return $this->apiError(Response::HTTP_BAD_REQUEST, 'DOCUMENT_PATIENT_REQUIRED');
         }
 
         $patientId = PatientIriParser::parsePatientIdFromPostPatientAbsoluteIri($patientRaw, $this->apiBaseUrl);
@@ -308,35 +297,32 @@ final class DocumentApiController extends AbstractController
             return $this->apiError(
                 Response::HTTP_BAD_REQUEST,
                 'DOCUMENT_PATIENT_ABSOLUTE_IRI_REQUIRED',
-                sprintf('Field "patient" must be exactly "%s/api/patients/{id}" (absolute IRI, matching API_BASE_URL).', $base),
-                ['apiBaseUrl' => $base]
+                ['apiBaseUrl' => $base],
+                ['%base_url%' => $base]
             );
         }
 
         $patient = $patientRepository->findById($patientId);
         if (!$patient) {
-            return $this->apiError(Response::HTTP_NOT_FOUND, 'PATIENT_NOT_FOUND', 'Patient not found');
+            return $this->apiError(Response::HTTP_NOT_FOUND, 'PATIENT_NOT_FOUND');
         }
 
         $size = $uploadedFile->getSize() ?? 0;
         if ($size <= 0) {
-            return $this->apiError(Response::HTTP_BAD_REQUEST, 'DOCUMENT_FILE_EMPTY', 'Uploaded file is empty.');
+            return $this->apiError(Response::HTTP_BAD_REQUEST, 'DOCUMENT_FILE_EMPTY');
         }
         if ($size > $this->maxUploadBytes) {
             return $this->apiError(
                 Response::HTTP_REQUEST_ENTITY_TOO_LARGE,
                 'DOCUMENT_FILE_TOO_LARGE',
-                sprintf('Uploaded file exceeds the maximum allowed size (%d bytes).', $this->maxUploadBytes)
+                [],
+                ['%max_bytes%' => (string) $this->maxUploadBytes]
             );
         }
 
         $extension = strtolower((string) $uploadedFile->getClientOriginalExtension());
         if ($extension === '' || !\array_key_exists($extension, self::ALLOWED_EXTENSIONS)) {
-            return $this->apiError(
-                Response::HTTP_BAD_REQUEST,
-                'DOCUMENT_FILE_EXTENSION_NOT_ALLOWED',
-                'File extension is not allowed.'
-            );
+            return $this->apiError(Response::HTTP_BAD_REQUEST, 'DOCUMENT_FILE_EXTENSION_NOT_ALLOWED');
         }
 
         $resolvedMimeFromExtension = self::ALLOWED_EXTENSIONS[$extension];
@@ -348,8 +334,8 @@ final class DocumentApiController extends AbstractController
             return $this->apiError(
                 Response::HTTP_BAD_REQUEST,
                 'DOCUMENT_FILE_MIME_NOT_ALLOWED',
-                'File MIME type is not allowed.',
-                ['mimeType' => $detectedMime]
+                ['mimeType' => $detectedMime],
+                ['%mime_type%' => $detectedMime]
             );
         }
 
@@ -357,8 +343,8 @@ final class DocumentApiController extends AbstractController
             return $this->apiError(
                 Response::HTTP_BAD_REQUEST,
                 'DOCUMENT_FILE_MIME_EXTENSION_MISMATCH',
-                'Detected MIME type does not match the file extension.',
-                ['mimeType' => $detectedMime, 'expectedMime' => $resolvedMimeFromExtension]
+                ['mimeType' => $detectedMime, 'expectedMime' => $resolvedMimeFromExtension],
+                ['%mime_type%' => $detectedMime, '%expected_mime%' => $resolvedMimeFromExtension]
             );
         }
 
@@ -370,15 +356,15 @@ final class DocumentApiController extends AbstractController
                 return $this->apiError(
                     Response::HTTP_BAD_REQUEST,
                     'DOCUMENT_TYPE_NOT_ALLOWED',
-                    'Provided type is not allowed.',
-                    ['type' => $typeRaw]
+                    ['type' => $typeRaw],
+                    ['%type%' => $typeRaw]
                 );
             } elseif ($typeRaw !== $resolvedMimeFromExtension) {
                 return $this->apiError(
                     Response::HTTP_BAD_REQUEST,
                     'DOCUMENT_TYPE_FILE_MISMATCH',
-                    'Declared type does not match the uploaded file.',
-                    ['type' => $typeRaw, 'expectedType' => $resolvedMimeFromExtension]
+                    ['type' => $typeRaw, 'expectedType' => $resolvedMimeFromExtension],
+                    ['%type%' => $typeRaw, '%expected_type%' => $resolvedMimeFromExtension]
                 );
             } else {
                 $finalStoredType = $typeRaw;
@@ -390,7 +376,7 @@ final class DocumentApiController extends AbstractController
         try {
             $filename = $this->handleFileStorage($uploadedFile, $patient);
         } catch (FileException) {
-            return $this->apiError(Response::HTTP_INTERNAL_SERVER_ERROR, 'DOCUMENT_FILE_STORE_FAILED', 'Could not upload file');
+            return $this->apiError(Response::HTTP_INTERNAL_SERVER_ERROR, 'DOCUMENT_FILE_STORE_FAILED');
         }
 
         $description = $request->request->get('description');
@@ -434,12 +420,12 @@ final class DocumentApiController extends AbstractController
 
         $patientId = PatientIriParser::parsePatientId($request->query->get('patientId'));
         if ($patientId === null) {
-            return $this->apiError(Response::HTTP_BAD_REQUEST, 'DOCUMENT_PATIENT_ID_REQUIRED', 'Query parameter patientId is required.');
+            return $this->apiError(Response::HTTP_BAD_REQUEST, 'DOCUMENT_PATIENT_ID_REQUIRED');
         }
 
         $document = $this->documentRepository->findById($id);
         if ($err = $this->documentPatientAccess->validateDocumentOwnership($document, $patientId)) {
-            return $this->apiError($err['status'], $err['code'], $err['message']);
+            return $this->apiError($err['status'], $err['code']);
         }
 
         return $this->json(DocumentApiSerializer::toArray($document, $this->apiBaseUrl), Response::HTTP_OK);
@@ -476,31 +462,23 @@ final class DocumentApiController extends AbstractController
         $document = $this->documentRepository->findById($id);
         $patientId = PatientIriParser::parsePatientId($request->query->get('patientId'));
         if ($patientId === null) {
-            return $this->apiError(Response::HTTP_BAD_REQUEST, 'DOCUMENT_PATIENT_ID_REQUIRED', 'Query parameter patientId is required.');
+            return $this->apiError(Response::HTTP_BAD_REQUEST, 'DOCUMENT_PATIENT_ID_REQUIRED');
         }
 
         if ($err = $this->documentPatientAccess->validateDocumentOwnership($document, $patientId)) {
-            return $this->apiError($err['status'], $err['code'], $err['message']);
+            return $this->apiError($err['status'], $err['code']);
         }
 
         $data = json_decode($request->getContent(), true);
         if (!\is_array($data)) {
-            return $this->apiError(Response::HTTP_BAD_REQUEST, 'INVALID_JSON', 'Invalid JSON');
+            return $this->apiError(Response::HTTP_BAD_REQUEST, 'INVALID_JSON');
         }
 
         if (!\array_key_exists('description', $data)) {
-            return $this->apiError(
-                Response::HTTP_BAD_REQUEST,
-                'DOCUMENT_DESCRIPTION_REQUIRED',
-                'Field "description" is required for document note updates.'
-            );
+            return $this->apiError(Response::HTTP_BAD_REQUEST, 'DOCUMENT_DESCRIPTION_REQUIRED');
         }
         if ($data['description'] !== null && !\is_string($data['description'])) {
-            return $this->apiError(
-                Response::HTTP_BAD_REQUEST,
-                'DOCUMENT_DESCRIPTION_INVALID',
-                'Field "description" must be a string or null.'
-            );
+            return $this->apiError(Response::HTTP_BAD_REQUEST, 'DOCUMENT_DESCRIPTION_INVALID');
         }
 
         $this->documentRepository->edit($document, ['description' => $data['description']]);
@@ -531,7 +509,7 @@ final class DocumentApiController extends AbstractController
 
         $document = $this->documentRepository->findById($documentId);
         if ($err = $this->documentPatientAccess->validateDocumentOwnership($document, $patientId)) {
-            return $this->apiError($err['status'], $err['code'], $err['message']);
+            return $this->apiError($err['status'], $err['code']);
         }
 
         $filePath = $this->getParameter('kernel.project_dir') . '/public/uploads/documents/' . $document->getFilePath();
@@ -548,7 +526,7 @@ final class DocumentApiController extends AbstractController
     {
         $patient = $patientRepository->findById($patientId);
         if (!$patient) {
-            return $this->apiError(Response::HTTP_NOT_FOUND, 'PATIENT_NOT_FOUND', 'Patient not found');
+            return $this->apiError(Response::HTTP_NOT_FOUND, 'PATIENT_NOT_FOUND');
         }
 
         $documents = $this->documentRepository->findByPatientOrdered($patient);
@@ -584,11 +562,7 @@ final class DocumentApiController extends AbstractController
 
     private function clinicalForbidden(): JsonResponse
     {
-        return $this->apiError(
-            Response::HTTP_FORBIDDEN,
-            'DOCUMENT_ACCESS_FORBIDDEN',
-            'You do not have permission to access patient documents.'
-        );
+        return $this->apiError(Response::HTTP_FORBIDDEN, 'DOCUMENT_ACCESS_FORBIDDEN');
     }
 
     private function handleFileStorage(UploadedFile $file, Patient $patient): string
@@ -604,8 +578,9 @@ final class DocumentApiController extends AbstractController
 
     /**
      * @param array<string, mixed> $details
+     * @param array<string, string|int|float|bool|null> $transParams
      */
-    private function apiError(int $status, string $code, string $message, array $details = []): JsonResponse
+    private function apiError(int $status, string $code, array $details = [], array $transParams = []): JsonResponse
     {
         $maxUploadBytes = null;
         if ($status === Response::HTTP_REQUEST_ENTITY_TOO_LARGE) {
@@ -614,9 +589,14 @@ final class DocumentApiController extends AbstractController
         }
 
         $payload = [
-            'error' => Response::$statusTexts[$status] ?? 'Error',
+            'error' => $this->apiHttpLine($status),
             'code' => $code,
-            'message' => $message,
+            'message' => $this->apiTrans(
+                ($code === 'DOCUMENT_FILE_TOO_LARGE' && isset($transParams['%max_bytes%']))
+                    ? 'DOCUMENT_FILE_TOO_LARGE_BYTES'
+                    : $code,
+                $transParams
+            ),
             'status' => $status,
             'details' => (object) $details,
         ];

--- a/src/Controller/Api/OdontogramApiController.php
+++ b/src/Controller/Api/OdontogramApiController.php
@@ -2,6 +2,7 @@
 
 namespace App\Controller\Api;
 
+use App\Controller\Api\Concerns\ApiTranslatorTrait;
 use App\Entity\Appointment;
 use App\Entity\Odontogram;
 use App\Entity\OdontogramDetail;
@@ -21,10 +22,13 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 #[Route('/api/odontograms')]
 final class OdontogramApiController extends AbstractController
 {
+    use ApiTranslatorTrait;
+
     private const STATUS_OPEN = 'Abierto';
 
     public function __construct(
@@ -33,6 +37,7 @@ final class OdontogramApiController extends AbstractController
         private readonly OdontogramDetailRepository $odontogramDetailRepository,
         private readonly PathologyRepository $pathologyRepository,
         private readonly EntityManagerInterface $entityManager,
+        private readonly TranslatorInterface $translator,
     ) {
     }
 
@@ -45,27 +50,27 @@ final class OdontogramApiController extends AbstractController
 
         if (!$this->isPositiveInt($patientId) || !$this->isPositiveInt($visitId)) {
             return $this->json([
-                'error' => 'patient_id and visit_id are required',
+                'error' => $this->apiTrans('ODO_PATIENT_VISIT_IDS_REQUIRED'),
             ], Response::HTTP_BAD_REQUEST);
         }
 
         $patient = $this->entityManager->find(Patient::class, (int) $patientId);
         if (!$patient instanceof Patient) {
             return $this->json([
-                'error' => 'Patient not found',
+                'error' => $this->apiTrans('PATIENT_NOT_FOUND'),
             ], Response::HTTP_NOT_FOUND);
         }
 
         $visit = $this->appointmentRepository->find((int) $visitId);
         if (!$visit instanceof Appointment) {
             return $this->json([
-                'error' => 'Appointment not found',
+                'error' => $this->apiTrans('ODO_APPOINTMENT_NOT_FOUND'),
             ], Response::HTTP_NOT_FOUND);
         }
 
         if ($visit->getPatient()?->getId() !== $patient->getId()) {
             return $this->json([
-                'error' => 'The appointment does not belong to the provided patient',
+                'error' => $this->apiTrans('ODO_APPOINTMENT_PATIENT_MISMATCH'),
             ], Response::HTTP_CONFLICT);
         }
 
@@ -93,13 +98,13 @@ final class OdontogramApiController extends AbstractController
             $this->rollBack();
 
             return $this->json([
-                'error' => 'Could not create or recover the odontogram',
+                'error' => $this->apiTrans('ODO_CREATE_OR_RECOVER_FAILED'),
                 'message' => $e->getMessage(),
             ], Response::HTTP_INTERNAL_SERVER_ERROR);
         }
 
         return $this->json([
-            'message' => $created ? 'Odontogram created successfully' : 'Open odontogram reused successfully',
+            'message' => $created ? $this->apiTrans('ODO_CREATED_SUCCESS') : $this->apiTrans('ODO_REUSED_SUCCESS'),
             'odontogram' => $this->serializeOdontogram($odontogram),
         ], $created ? Response::HTTP_CREATED : Response::HTTP_OK);
     }
@@ -110,7 +115,7 @@ final class OdontogramApiController extends AbstractController
         $odontogram = $this->odontogramRepository->find($odontogramId);
         if (!$odontogram instanceof Odontogram) {
             return $this->json([
-                'error' => 'Odontogram not found',
+                'error' => $this->apiTrans('ODO_NOT_FOUND'),
             ], Response::HTTP_NOT_FOUND);
         }
 
@@ -121,20 +126,20 @@ final class OdontogramApiController extends AbstractController
 
         if (!$this->isPositiveInt($pathologyId) || !$this->isPositiveInt($toothNumber)) {
             return $this->json([
-                'error' => 'pathology_id and tooth_number are required',
+                'error' => $this->apiTrans('ODO_PATHOLOGY_TOOTH_REQUIRED'),
             ], Response::HTTP_BAD_REQUEST);
         }
 
         if (!is_array($faces)) {
             return $this->json([
-                'error' => 'faces must be an array',
+                'error' => $this->apiTrans('ODO_FACES_MUST_BE_ARRAY'),
             ], Response::HTTP_BAD_REQUEST);
         }
 
         $pathology = $this->pathologyRepository->find((int) $pathologyId);
         if (!$pathology instanceof Pathology) {
             return $this->json([
-                'error' => 'Pathology not found',
+                'error' => $this->apiTrans('ODO_PATHOLOGY_NOT_FOUND'),
             ], Response::HTTP_NOT_FOUND);
         }
 
@@ -163,13 +168,13 @@ final class OdontogramApiController extends AbstractController
             $this->rollBack();
 
             return $this->json([
-                'error' => 'Could not create the odontogram detail',
+                'error' => $this->apiTrans('ODO_DETAIL_CREATE_FAILED'),
                 'message' => $e->getMessage(),
             ], Response::HTTP_INTERNAL_SERVER_ERROR);
         }
 
         return $this->json([
-            'message' => 'Pathology added to tooth successfully',
+            'message' => $this->apiTrans('ODO_PATHOLOGY_ADDED_OK'),
             'detail' => $this->serializeDetail($detail),
         ], Response::HTTP_CREATED);
     }
@@ -180,7 +185,7 @@ final class OdontogramApiController extends AbstractController
         $odontogram = $this->odontogramRepository->find($odontogramId);
         if (!$odontogram instanceof Odontogram) {
             return $this->json([
-                'error' => 'Odontogram not found',
+                'error' => $this->apiTrans('ODO_NOT_FOUND'),
             ], Response::HTTP_NOT_FOUND);
         }
 
@@ -189,14 +194,14 @@ final class OdontogramApiController extends AbstractController
 
         if (!$this->isPositiveInt($visitId)) {
             return $this->json([
-                'error' => 'visit_id is required',
+                'error' => $this->apiTrans('ODO_VISIT_ID_REQUIRED'),
             ], Response::HTTP_BAD_REQUEST);
         }
 
         $visit = $this->appointmentRepository->find((int) $visitId);
         if (!$visit instanceof Appointment) {
             return $this->json([
-                'error' => 'Appointment not found',
+                'error' => $this->apiTrans('ODO_APPOINTMENT_NOT_FOUND'),
             ], Response::HTTP_NOT_FOUND);
         }
 
@@ -205,7 +210,7 @@ final class OdontogramApiController extends AbstractController
 
         if ($odontogramPatientId !== null && $visitPatientId !== $odontogramPatientId) {
             return $this->json([
-                'error' => 'The appointment does not belong to the odontogram patient',
+                'error' => $this->apiTrans('ODO_APPOINTMENT_PATIENT_MISMATCH'),
             ], Response::HTTP_CONFLICT);
         }
 
@@ -242,13 +247,13 @@ final class OdontogramApiController extends AbstractController
             $this->rollBack();
 
             return $this->json([
-                'error' => 'Could not create the treatment and sync the visit',
+                'error' => $this->apiTrans('ODO_TREATMENT_SYNC_FAILED'),
                 'message' => $e->getMessage(),
             ], Response::HTTP_INTERNAL_SERVER_ERROR);
         }
 
         return $this->json([
-            'message' => 'Treatment created and visit synchronized successfully',
+            'message' => $this->apiTrans('ODO_TREATMENT_SYNC_OK'),
             'treatment' => $this->serializeTreatment($treatment),
             'odontogram' => $this->serializeOdontogram($odontogram),
         ], Response::HTTP_CREATED);
@@ -260,7 +265,7 @@ final class OdontogramApiController extends AbstractController
         $odontogram = $this->odontogramRepository->find($odontogramId);
         if (!$odontogram instanceof Odontogram) {
             return $this->json([
-                'error' => 'Odontogram not found',
+                'error' => $this->apiTrans('ODO_NOT_FOUND'),
             ], Response::HTTP_NOT_FOUND);
         }
 
@@ -269,7 +274,7 @@ final class OdontogramApiController extends AbstractController
 
         if (!is_array($entries)) {
             return $this->json([
-                'error' => 'entries must be an array',
+                'error' => $this->apiTrans('ODO_ENTRIES_MUST_BE_ARRAY'),
             ], Response::HTTP_BAD_REQUEST);
         }
 
@@ -277,7 +282,7 @@ final class OdontogramApiController extends AbstractController
             $normalizedEntries = $this->normalizeSyncEntries($entries);
         } catch (\InvalidArgumentException $exception) {
             return $this->json([
-                'error' => $exception->getMessage(),
+                'error' => $this->apiTrans('ODO_SYNC_ENTRIES_INVALID', ['%reason%' => $exception->getMessage()]),
             ], Response::HTTP_BAD_REQUEST);
         }
 
@@ -318,13 +323,13 @@ final class OdontogramApiController extends AbstractController
             $this->rollBack();
 
             return $this->json([
-                'error' => 'Could not synchronize the odontogram details',
+                'error' => $this->apiTrans('ODO_DETAILS_SYNC_FAILED'),
                 'message' => $e->getMessage(),
             ], Response::HTTP_INTERNAL_SERVER_ERROR);
         }
 
         return $this->json([
-            'message' => 'Odontogram details synchronized successfully',
+            'message' => $this->apiTrans('ODO_DETAILS_SYNC_OK'),
             'odontogram' => $this->serializeOdontogram($odontogram),
         ], Response::HTTP_OK);
     }
@@ -336,7 +341,7 @@ final class OdontogramApiController extends AbstractController
 
         if (!$odontogram instanceof Odontogram) {
             return $this->json([
-                'message' => 'Odontogram not found',
+                'message' => $this->apiTrans('ODO_NOT_FOUND'),
             ], Response::HTTP_NOT_FOUND);
         }
 
@@ -349,7 +354,7 @@ final class OdontogramApiController extends AbstractController
         $odontogram = $this->odontogramRepository->find($odontogramId);
         if (!$odontogram instanceof Odontogram) {
             return $this->json([
-                'message' => 'Odontogram not found',
+                'message' => $this->apiTrans('ODO_NOT_FOUND'),
             ], Response::HTTP_NOT_FOUND);
         }
 
@@ -368,7 +373,7 @@ final class OdontogramApiController extends AbstractController
 
         if (!$detail instanceof OdontogramDetail) {
             return $this->json([
-                'error' => 'Odontogram detail not found',
+                'error' => $this->apiTrans('ODO_DETAIL_NOT_FOUND'),
             ], Response::HTTP_NOT_FOUND);
         }
 
@@ -386,7 +391,7 @@ final class OdontogramApiController extends AbstractController
             $this->rollBack();
 
             return $this->json([
-                'error' => 'Could not delete the odontogram detail',
+                'error' => $this->apiTrans('ODO_DETAIL_DELETE_FAILED'),
                 'message' => $e->getMessage(),
             ], Response::HTTP_INTERNAL_SERVER_ERROR);
         }

--- a/src/Controller/Api/PatientApiController.php
+++ b/src/Controller/Api/PatientApiController.php
@@ -2,6 +2,7 @@
 
 namespace App\Controller\Api;
 
+use App\Controller\Api\Concerns\ApiTranslatorTrait;
 use App\Entity\Patient;
 use App\Entity\User;
 use App\Repository\AppointmentRepository;
@@ -21,6 +22,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * JSON paciente:
@@ -32,8 +34,11 @@ use Symfony\Component\Routing\Attribute\Route;
 #[OA\Tag(name: 'Patients')]
 final class PatientApiController extends AbstractController
 {
+    use ApiTranslatorTrait;
+
     public function __construct(
         private readonly PatientRecordsAccessChecker $patientRecordsAccess,
+        private readonly TranslatorInterface $translator,
     ) {
     }
 
@@ -89,14 +94,17 @@ final class PatientApiController extends AbstractController
     ): JsonResponse {
         if (!$this->patientRecordsAccess->canAccessPatientClinicalApi()) {
             return $this->json(
-                ['error' => 'Forbidden', 'message' => 'You do not have permission to list patient documents.'],
+                [
+                    'error' => $this->apiHttpLine(Response::HTTP_FORBIDDEN),
+                    'message' => $this->apiTrans('PATIENT_DOCUMENTS_LIST_FORBIDDEN'),
+                ],
                 Response::HTTP_FORBIDDEN
             );
         }
 
         $patient = $repo->findById($id);
         if (!$patient) {
-            return $this->json(['message' => 'Patient not found'], Response::HTTP_NOT_FOUND);
+            return $this->json(['message' => $this->apiTrans('PATIENT_NOT_FOUND')], Response::HTTP_NOT_FOUND);
         }
 
         $documents = $documentRepository->findByPatientOrdered($patient);
@@ -125,14 +133,17 @@ final class PatientApiController extends AbstractController
     ): JsonResponse {
         if (!$this->patientRecordsAccess->canAccessPatientClinicalApi()) {
             return $this->json(
-                ['error' => 'Forbidden', 'message' => 'You do not have permission to list patient appointments.'],
+                [
+                    'error' => $this->apiHttpLine(Response::HTTP_FORBIDDEN),
+                    'message' => $this->apiTrans('PATIENT_APPOINTMENTS_LIST_FORBIDDEN'),
+                ],
                 Response::HTTP_FORBIDDEN
             );
         }
 
         $patient = $repo->findById($id);
         if (!$patient) {
-            return $this->json(['message' => 'Patient not found'], Response::HTTP_NOT_FOUND);
+            return $this->json(['message' => $this->apiTrans('PATIENT_NOT_FOUND')], Response::HTTP_NOT_FOUND);
         }
 
         $appointments = $appointmentRepository->findByPatient($patient);
@@ -155,7 +166,7 @@ final class PatientApiController extends AbstractController
     {
         $patient = $repo->findById($id);
         if (!$patient) {
-            return $this->json(['message' => 'Patient not found'], Response::HTTP_NOT_FOUND);
+            return $this->json(['message' => $this->apiTrans('PATIENT_NOT_FOUND')], Response::HTTP_NOT_FOUND);
         }
 
         return $this->json(self::serializePatient($patient), Response::HTTP_OK);
@@ -176,7 +187,7 @@ final class PatientApiController extends AbstractController
     {
         $patients = $repo->findByIdentityDocument($identityDocument);
         if (empty($patients)) {
-            return $this->json(['message' => 'No patients found'], Response::HTTP_NOT_FOUND);
+            return $this->json(['message' => $this->apiTrans('PATIENTS_NONE_BY_IDENTITY')], Response::HTTP_NOT_FOUND);
         }
 
         $data = array_map(static fn (Patient $patient) => self::serializePatient($patient), $patients);
@@ -211,25 +222,25 @@ final class PatientApiController extends AbstractController
         $required = ['identityDocument', 'firstName', 'lastName', 'phone', 'email', 'address', 'consultationReason', 'familyHistory', 'healthStatus', 'lifestyleHabits'];
         foreach ($required as $field) {
             if (!isset($data[$field]) || trim((string) $data[$field]) === '') {
-                return $this->json(['message' => 'Missing required fields'], Response::HTTP_BAD_REQUEST);
+                return $this->json(['message' => $this->apiTrans('PATIENT_CREATE_MISSING_FIELDS')], Response::HTTP_BAD_REQUEST);
             }
         }
 
         $allergiesResolved = PatientMedicationAllergiesResolver::resolveForCreate($data);
         if (!$allergiesResolved['ok']) {
-            return $this->json(['message' => $allergiesResolved['message']], Response::HTTP_BAD_REQUEST);
+            return $this->json(['message' => $this->apiTrans($allergiesResolved['messageKey'])], Response::HTTP_BAD_REQUEST);
         }
 
         $allergiesBitmask = $this->resolveAllergiesBitmask($data);
 
         $identityDocument = (string) $data['identityDocument'];
         if ($repo->findOneByIdentityDocument($identityDocument)) {
-            return $this->json(['message' => 'Patient already exists'], Response::HTTP_BAD_REQUEST);
+            return $this->json(['message' => $this->apiTrans('PATIENT_CREATE_ALREADY_EXISTS')], Response::HTTP_BAD_REQUEST);
         }
 
         $email = (string) $data['email'];
         if ($userRepository->findOneByEmailCaseInsensitive($email)) {
-            return $this->json(['message' => 'Email already registered'], Response::HTTP_BAD_REQUEST);
+            return $this->json(['message' => $this->apiTrans('EMAIL_ALREADY_REGISTERED')], Response::HTTP_BAD_REQUEST);
         }
 
         $patient = new Patient();
@@ -251,7 +262,7 @@ final class PatientApiController extends AbstractController
             try {
                 $patient->setRegistrationDate(new \DateTimeImmutable((string) $data['registrationDate']));
             } catch (\Throwable) {
-                return $this->json(['message' => 'Invalid registrationDate format'], Response::HTTP_BAD_REQUEST);
+                return $this->json(['message' => $this->apiTrans('PATIENT_INVALID_REGISTRATION_DATE')], Response::HTTP_BAD_REQUEST);
             }
         } else {
             $patient->setRegistrationDate(new \DateTimeImmutable());
@@ -261,7 +272,9 @@ final class PatientApiController extends AbstractController
         if ($profilePick['present'] ?? false) {
             $normalized = PatientProfileImageResolver::validateAndNormalize($profilePick['value']);
             if (!$normalized['ok']) {
-                return $this->json(['message' => $normalized['message']], Response::HTTP_BAD_REQUEST);
+                return $this->json([
+                    'message' => $this->apiTrans($normalized['messageKey'], $normalized['messageParams'] ?? []),
+                ], Response::HTTP_BAD_REQUEST);
             }
             $patient->setProfileImage($normalized['value']);
         }
@@ -303,14 +316,17 @@ final class PatientApiController extends AbstractController
     {
         if (!$this->patientRecordsAccess->canAccessPatientClinicalApi()) {
             return $this->json(
-                ['error' => 'Forbidden', 'message' => 'You do not have permission to update patients.'],
+                [
+                    'error' => $this->apiHttpLine(Response::HTTP_FORBIDDEN),
+                    'message' => $this->apiTrans('PATIENT_UPDATE_FORBIDDEN'),
+                ],
                 Response::HTTP_FORBIDDEN
             );
         }
 
         $patient = $repo->findById($id);
         if (!$patient) {
-            return $this->json(['message' => 'Patient not found'], Response::HTTP_NOT_FOUND);
+            return $this->json(['message' => $this->apiTrans('PATIENT_NOT_FOUND')], Response::HTTP_NOT_FOUND);
         }
 
         $data = $request->getContentTypeFormat() === 'json' ? $request->toArray() : $request->request->all();
@@ -351,8 +367,8 @@ final class PatientApiController extends AbstractController
 
         $allergiesUpdate = PatientMedicationAllergiesResolver::resolveForPartialUpdate($data);
         if (($allergiesUpdate['apply'] ?? false) === true) {
-            if (isset($allergiesUpdate['error'])) {
-                return $this->json(['message' => $allergiesUpdate['error']], Response::HTTP_BAD_REQUEST);
+            if (isset($allergiesUpdate['errorKey'])) {
+                return $this->json(['message' => $this->apiTrans($allergiesUpdate['errorKey'])], Response::HTTP_BAD_REQUEST);
             }
             $patient->setMedicationAllergies($allergiesUpdate['value']);
         }
@@ -368,7 +384,9 @@ final class PatientApiController extends AbstractController
         if ($profilePick['present'] ?? false) {
             $normalized = PatientProfileImageResolver::validateAndNormalize($profilePick['value']);
             if (!$normalized['ok']) {
-                return $this->json(['message' => $normalized['message']], Response::HTTP_BAD_REQUEST);
+                return $this->json([
+                    'message' => $this->apiTrans($normalized['messageKey'], $normalized['messageParams'] ?? []),
+                ], Response::HTTP_BAD_REQUEST);
             }
             $patient->setProfileImage($normalized['value']);
         }
@@ -377,7 +395,7 @@ final class PatientApiController extends AbstractController
             try {
                 $patient->setRegistrationDate(new \DateTimeImmutable((string) $data['registrationDate']));
             } catch (\Throwable) {
-                return $this->json(['message' => 'Invalid registrationDate format'], Response::HTTP_BAD_REQUEST);
+                return $this->json(['message' => $this->apiTrans('PATIENT_INVALID_REGISTRATION_DATE')], Response::HTTP_BAD_REQUEST);
             }
         }
 
@@ -401,7 +419,7 @@ final class PatientApiController extends AbstractController
     {
         $patient = $repo->findById($id);
         if (!$patient) {
-            return $this->json(['message' => 'Patient not found'], Response::HTTP_NOT_FOUND);
+            return $this->json(['message' => $this->apiTrans('PATIENT_NOT_FOUND')], Response::HTTP_NOT_FOUND);
         }
 
         $repo->delete($patient);

--- a/src/Controller/Api/TreatmentController.php
+++ b/src/Controller/Api/TreatmentController.php
@@ -2,6 +2,7 @@
 
 namespace App\Controller\Api;
 
+use App\Controller\Api\Concerns\ApiTranslatorTrait;
 use App\Entity\Treatment;
 use App\Repository\TreatmentRepository;
 use App\Repository\AppointmentRepository;
@@ -13,11 +14,18 @@ use Symfony\Component\HttpFoundation\Request;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 
 #[Route('/api/treatments')]
 final class TreatmentController extends AbstractController
 {
+    use ApiTranslatorTrait;
+
+    public function __construct(
+        private readonly TranslatorInterface $translator,
+    ) {
+    }
     /**
      * CREATE: Crea un nuevo tratamiento y lo vincula a la cita abierta en el odontograma.
      */
@@ -31,7 +39,7 @@ final class TreatmentController extends AbstractController
         $data = json_decode($request->getContent(), true);
         
         if (!$data) {
-            return $this->json(['error' => 'Dades invàlides'], 400);
+            return $this->json(['error' => $this->apiTrans('TREATMENT_INVALID_JSON')], 400);
         }
 
         $treatment = new Treatment();
@@ -69,7 +77,7 @@ final class TreatmentController extends AbstractController
         return $this->json([
             'id' => $treatment->getId(),
             'status' => 'success',
-            'message' => 'Tractament creat i vinculat a la cita correctament'
+            'message' => $this->apiTrans('TREATMENT_CREATED_LINKED')
         ]);
     }
 
@@ -79,7 +87,7 @@ final class TreatmentController extends AbstractController
         $treatment = $treatmentRepository->find($id);
 
         if (!$treatment) {
-            return $this->json(['error' => 'Tractament no trobat'], 404);
+            return $this->json(['error' => $this->apiTrans('TREATMENT_NOT_FOUND')], 404);
         }
 
         return $this->json([
@@ -98,7 +106,7 @@ final class TreatmentController extends AbstractController
         $treatment = $treatmentRepository->find($id);
 
         if (!$treatment) {
-            return $this->json(['error' => 'Tractament no trobat'], 404);
+            return $this->json(['error' => $this->apiTrans('TREATMENT_NOT_FOUND')], 404);
         }
 
         $data = json_decode($request->getContent(), true);
@@ -122,9 +130,9 @@ final class TreatmentController extends AbstractController
         $em->flush();
 
         return $this->json([
-            'message' => 'Tractament actualitzat correctament',
+            'message' => $this->apiTrans('TREATMENT_UPDATED_OK'),
             'id' => $treatment->getId(),
-            'status' => 'success'
+            'status' => 'success',
         ]);
     }
 
@@ -134,15 +142,15 @@ final class TreatmentController extends AbstractController
         $treatment = $treatmentRepository->find($id);
 
         if (!$treatment) {
-            return $this->json(['error' => 'Tractament no trobat'], 404);
+            return $this->json(['error' => $this->apiTrans('TREATMENT_NOT_FOUND')], 404);
         }
         
         $em->remove($treatment);
         $em->flush();
 
         return $this->json([
-            'message' => 'Tractament eliminat correctament',
-            'status' => 'success'
+            'message' => $this->apiTrans('TREATMENT_DELETED_OK'),
+            'status' => 'success',
         ]);
     }
 
@@ -176,12 +184,12 @@ final class TreatmentController extends AbstractController
         $rowsUpdated = $treatmentRepo->markAsFinished($id);
 
         if ($rowsUpdated === 0) {
-            return $this->json(['error' => 'No se ha encontrado el tratamiento o ya estaba finalizado'], 404);
+            return $this->json(['error' => $this->apiTrans('TREATMENT_ALREADY_FINISHED_OR_MISSING')], 404);
         }
 
         return $this->json([
             'status' => 'success',
-            'message' => 'Tractament marcat com a Finalitzat'
+            'message' => $this->apiTrans('TREATMENT_FINISHED_OK')
         ]);
     }
 }

--- a/src/Controller/Api/UserController.php
+++ b/src/Controller/Api/UserController.php
@@ -2,6 +2,7 @@
 
 namespace App\Controller\Api;
 
+use App\Controller\Api\Concerns\ApiTranslatorTrait;
 use App\Entity\User;
 use App\Form\UserType;
 use App\Repository\UserRepository;
@@ -14,15 +15,19 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 #[Route('/api/users')]
 #[OA\Tag(name: 'Users')]
 final class UserController extends AbstractController
 {
+    use ApiTranslatorTrait;
+
     public function __construct(
         private readonly EntityManagerInterface $entityManager,
         private readonly UserRepository $userRepository,
         private readonly UserPasswordHasherInterface $passwordHasher,
+        private readonly TranslatorInterface $translator,
     ) {
     }
 
@@ -81,7 +86,10 @@ final class UserController extends AbstractController
     public function show(User $user): JsonResponse
     {
         if (!$this->canAccessUser($user)) {
-            return $this->json(['error' => 'Forbidden', 'message' => 'You can only access your own user profile.'], Response::HTTP_FORBIDDEN);
+            return $this->json([
+                'error' => $this->apiHttpLine(Response::HTTP_FORBIDDEN),
+                'message' => $this->apiTrans('USER_ACCESS_PROFILE_FORBIDDEN'),
+            ], Response::HTTP_FORBIDDEN);
         }
 
         return $this->json($this->serializeUser($user), Response::HTTP_OK);
@@ -119,7 +127,7 @@ final class UserController extends AbstractController
         $form = $this->createForm(UserType::class, $user, ['require_password' => true, 'csrf_protection' => false]);
         $requestData = self::getRequestData($request);
         self::applyProfileImageAliases($requestData);
-        if (($response = self::normalizeProfileImageInRequest($requestData)) instanceof JsonResponse) {
+        if (($response = $this->normalizeProfileImageInRequest($requestData)) instanceof JsonResponse) {
             return $response;
         }
         $form->submit($requestData);
@@ -169,12 +177,15 @@ final class UserController extends AbstractController
     public function update(Request $request, User $user): JsonResponse
     {
         if (!$this->canAccessUser($user)) {
-            return $this->json(['error' => 'Forbidden', 'message' => 'You can only update your own user profile.'], Response::HTTP_FORBIDDEN);
+            return $this->json([
+                'error' => $this->apiHttpLine(Response::HTTP_FORBIDDEN),
+                'message' => $this->apiTrans('USER_UPDATE_PROFILE_FORBIDDEN'),
+            ], Response::HTTP_FORBIDDEN);
         }
 
         $requestData = self::getRequestData($request);
         self::applyProfileImageAliases($requestData);
-        if (($response = self::normalizeProfileImageInRequest($requestData)) instanceof JsonResponse) {
+        if (($response = $this->normalizeProfileImageInRequest($requestData)) instanceof JsonResponse) {
             return $response;
         }
 
@@ -213,6 +224,13 @@ final class UserController extends AbstractController
     )]
     public function delete(User $user): JsonResponse
     {
+        if (!$this->isGranted('ROLE_ADMIN')) {
+            return $this->json([
+                'error' => $this->apiHttpLine(Response::HTTP_FORBIDDEN),
+                'message' => $this->apiTrans('USER_DELETE_ADMIN_ONLY'),
+            ], Response::HTTP_FORBIDDEN);
+        }
+
         $this->entityManager->remove($user);
         $this->entityManager->flush();
 
@@ -240,7 +258,7 @@ final class UserController extends AbstractController
         }
 
         return new JsonResponse([
-            'error' => 'Validation failed',
+            'error' => $this->apiTrans('AUTH_VALIDATION_FAILED'),
             'errors' => $errors,
         ], Response::HTTP_UNPROCESSABLE_ENTITY);
     }
@@ -270,7 +288,7 @@ final class UserController extends AbstractController
     /**
      * Validates and normalizes `profileImage` in place (empty string → null) when present.
      */
-    private static function normalizeProfileImageInRequest(array &$requestData): ?JsonResponse
+    private function normalizeProfileImageInRequest(array &$requestData): ?JsonResponse
     {
         if (!array_key_exists('profileImage', $requestData)) {
             return null;
@@ -279,8 +297,8 @@ final class UserController extends AbstractController
         $result = PatientProfileImageResolver::validateAndNormalize($requestData['profileImage']);
         if (!$result['ok']) {
             return new JsonResponse([
-                'error' => 'Validation failed',
-                'message' => $result['message'],
+                'error' => $this->apiTrans('AUTH_VALIDATION_FAILED'),
+                'message' => $this->apiTrans($result['messageKey'], $result['messageParams'] ?? []),
             ], Response::HTTP_BAD_REQUEST);
         }
         $requestData['profileImage'] = $result['value'];

--- a/src/EventSubscriber/ApiLocaleSubscriber.php
+++ b/src/EventSubscriber/ApiLocaleSubscriber.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventSubscriber;
+
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Contracts\Translation\LocaleAwareInterface;
+
+/**
+ * Establece Request::locale para la API según Accept-Language (o query ?locale=).
+ * El frontend Angular envía `Accept-Language` en todas las peticiones a `/api/`
+ * (repo **FalconCare**: `src/app/interceptors/locale.interceptor.ts` + `LanguageService`).
+ * Idiomas soportados: ca, es, en, fr (alineados con ngx-translate).
+ *
+ * Contrato verificado en `tests/Controller/Api/ApiAcceptLanguageTest.php`.
+ */
+final class ApiLocaleSubscriber implements EventSubscriberInterface
+{
+    /** @var list<string> */
+    public const SUPPORTED_LOCALES = ['ca', 'es', 'en', 'fr'];
+
+    public function __construct(
+        #[Autowire(service: 'translator')]
+        private LocaleAwareInterface $translator,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            // Después de LocaleListener (16) y LocaleAwareListener (15): si no, el núcleo vuelve a fijar el locale por defecto.
+            // LocaleAwareListener ya copió ese locale al traductor; hay que volver a sincronizar tras cambiar Request::locale.
+            KernelEvents::REQUEST => ['onKernelRequest', 8],
+        ];
+    }
+
+    public function onKernelRequest(RequestEvent $event): void
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
+        $request = $event->getRequest();
+        if (!str_starts_with($request->getPathInfo(), '/api')) {
+            return;
+        }
+
+        $fromQuery = $request->query->get('locale');
+        if (\is_string($fromQuery) && $fromQuery !== '') {
+            $normalized = $this->normalizeLocale($fromQuery);
+            if ($normalized !== null) {
+                $this->applyLocale($request, $normalized);
+
+                return;
+            }
+        }
+
+        foreach ($request->getLanguages() as $lang) {
+            $normalized = $this->normalizeLocale($lang);
+            if ($normalized !== null) {
+                $this->applyLocale($request, $normalized);
+
+                return;
+            }
+        }
+    }
+
+    private function applyLocale(Request $request, string $normalized): void
+    {
+        $request->setLocale($normalized);
+        $this->translator->setLocale($normalized);
+    }
+
+    private function normalizeLocale(string $raw): ?string
+    {
+        $trimmed = strtolower(trim($raw));
+        if ($trimmed === '') {
+            return null;
+        }
+
+        $primary = preg_match('/^([a-z]{2})(?:[-_][a-z]+)?$/i', $trimmed, $m) === 1
+            ? strtolower($m[1])
+            : $trimmed;
+
+        return \in_array($primary, self::SUPPORTED_LOCALES, true) ? $primary : null;
+    }
+}

--- a/src/Repository/AppointmentRepository.php
+++ b/src/Repository/AppointmentRepository.php
@@ -3,6 +3,7 @@
 namespace App\Repository;
 
 use App\Entity\Appointment;
+use App\Entity\Patient;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -42,6 +43,21 @@ class AppointmentRepository extends ServiceEntityRepository
             ->getResult();
     }
 
+    /**
+     * Citas de un paciente (historial clínico / panel Angular), más recientes primero.
+     *
+     * @return list<Appointment>
+     */
+    public function findByPatient(Patient $patient): array
+    {
+        return $this->createQueryBuilder('a')
+            ->andWhere('a.patient = :patient')
+            ->setParameter('patient', $patient)
+            ->orderBy('a.visitDate', 'DESC')
+            ->addOrderBy('a.visitTime', 'DESC')
+            ->getQuery()
+            ->getResult();
+    }
 
     public function findOverlappingAppointments($date, $startTime, int $duration, $boxId, $excludeId = null, ?int $cleaningMinutes = null): array 
     {

--- a/src/Service/AppointmentListSerializer.php
+++ b/src/Service/AppointmentListSerializer.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Entity\Appointment;
+
+/**
+ * Lista de citas en JSON (misma forma que {@see \App\Controller\Api\AppointmentController} index/weekly)
+ * para reutilizar en subrecursos (p. ej. historial por paciente).
+ */
+final class AppointmentListSerializer
+{
+    private const STATUS_SCHEDULED = 'Programada';
+    private const STATUS_MISSING_CONSENT = 'Falta consentiment';
+    private const STATUS_IN_PROGRESS = 'En curs';
+    private const STATUS_FINISHED = 'Finalitzada';
+
+    public function normalizeStatus(?string $status): string
+    {
+        $status = trim((string) $status);
+
+        if ($status === '') {
+            return self::STATUS_SCHEDULED;
+        }
+
+        return match ($status) {
+            'Encurs' => self::STATUS_IN_PROGRESS,
+            'Falta Consentiment' => self::STATUS_MISSING_CONSENT,
+            'Cancel·lada', 'CancelÂ·lada' => 'Cancelada',
+            default => $status,
+        };
+    }
+
+    /**
+     * @param list<Appointment> $appointments
+     * @return list<array<string, mixed>>
+     */
+    public function serializeList(array $appointments): array
+    {
+        $result = [];
+        foreach ($appointments as $appointment) {
+            $reason = $appointment->getConsultationReason() ?? '';
+            $status = $this->normalizeStatus($appointment->getStatus());
+
+            $isUrgency = $appointment->isUrgency() || str_contains(strtolower($reason), 'urgència') || str_contains(strtolower($reason), 'urgencia');
+            $isFirstVisit = $appointment->isFirstVisit() || str_contains(strtolower($reason), 'primera visita');
+
+            if ($status === 'Finalitzada') {
+                $color = '#9e9e9e';
+            } elseif ($isUrgency) {
+                $color = '#e91e63';
+            } elseif ($isFirstVisit) {
+                $color = '#9c27b0';
+            } else {
+                $color = '#00bcd4';
+            }
+
+            $patient = $appointment->getPatient();
+
+            $result[] = [
+                'id' => $appointment->getId(),
+                'date' => $appointment->getVisitDate()->format('Y-m-d'),
+                'time' => $appointment->getVisitTime() ? $appointment->getVisitTime()->format('H:i') : '--:--',
+                'duration' => $appointment->getDurationMinutes() ?? 30,
+                'cleaningTime' => $appointment->getCleaningMinutes(),
+                'cleaning_time' => $appointment->getCleaningMinutes(),
+                'cleaningMinutes' => $appointment->getCleaningMinutes(),
+                'totalBlockTime' => $appointment->getTotalDurationWithCleaning(),
+                'patientId' => $patient ? $patient->getId() : null,
+                'patientName' => $patient
+                    ? $patient->getFirstName().' '.$patient->getLastName()
+                    : 'Sense Pacient',
+                'doctorName' => $appointment->getDoctor()
+                    ? trim($appointment->getDoctor()->getFirstName().' '.$appointment->getDoctor()->getLastNames())
+                    : 'Sense Doctor',
+                'doctorId' => $appointment->getDoctor() ? $appointment->getDoctor()->getId() : null,
+                'boxId' => $appointment->getBox() ? $appointment->getBox()->getId() : null,
+                'box' => $appointment->getBox() ? $appointment->getBox()->getBoxName() : 'Sense Box',
+                'reason' => $reason,
+                'status' => $status,
+                'color' => $color,
+                'isUrgency' => $isUrgency,
+                'isFirstVisit' => $isFirstVisit,
+            ];
+        }
+
+        return $result;
+    }
+}

--- a/src/Service/DocumentPatientAccessGuard.php
+++ b/src/Service/DocumentPatientAccessGuard.php
@@ -12,7 +12,7 @@ use App\Entity\Document;
 final class DocumentPatientAccessGuard
 {
     /**
-     * @return array{status: int, code: string, message: string}|null null si el documento existe y pertenece al paciente
+     * @return array{status: int, code: string}|null null si el documento existe y pertenece al paciente
      */
     public function validateDocumentOwnership(?Document $document, int $patientId): ?array
     {
@@ -20,7 +20,6 @@ final class DocumentPatientAccessGuard
             return [
                 'status' => 404,
                 'code' => 'DOCUMENT_NOT_FOUND',
-                'message' => 'Document not found',
             ];
         }
 
@@ -28,7 +27,6 @@ final class DocumentPatientAccessGuard
             return [
                 'status' => 403,
                 'code' => 'DOCUMENT_PATIENT_MISMATCH',
-                'message' => 'Document does not belong to the indicated patient.',
             ];
         }
 

--- a/src/Util/PatientMedicationAllergiesResolver.php
+++ b/src/Util/PatientMedicationAllergiesResolver.php
@@ -13,7 +13,7 @@ final class PatientMedicationAllergiesResolver
     /**
      * For POST: requires at least one key; values must be non-empty after trim; both keys must match if present.
      *
-     * @return array{ok: true, value: string}|array{ok: false, message: string}
+     * @return array{ok: true, value: string}|array{ok: false, messageKey: string}
      */
     public static function resolveForCreate(array $data): array
     {
@@ -21,16 +21,16 @@ final class PatientMedicationAllergiesResolver
         $hasSnake = \array_key_exists('medication_allergies', $data);
 
         if (!$hasCamel && !$hasSnake) {
-            return ['ok' => false, 'message' => 'Missing required fields'];
+            return ['ok' => false, 'messageKey' => 'PATIENT_ALLERGIES_REQUIRED'];
         }
 
         $r = self::mergeTwoKeys($data, $hasCamel, $hasSnake);
-        if ($r['error'] !== null) {
-            return ['ok' => false, 'message' => $r['error']];
+        if ($r['errorKey'] !== null) {
+            return ['ok' => false, 'messageKey' => $r['errorKey']];
         }
 
         if ($r['value'] === '') {
-            return ['ok' => false, 'message' => 'Missing required fields'];
+            return ['ok' => false, 'messageKey' => 'PATIENT_ALLERGIES_REQUIRED'];
         }
 
         return ['ok' => true, 'value' => $r['value']];
@@ -39,7 +39,7 @@ final class PatientMedicationAllergiesResolver
     /**
      * For PUT partial update: returns null if neither key sent; otherwise resolved value or error if mismatch.
      *
-     * @return array{apply: false}|array{apply: true, value: string}|array{apply: true, error: string}
+     * @return array{apply: false}|array{apply: true, value: string}|array{apply: true, errorKey: string}
      */
     public static function resolveForPartialUpdate(array $data): array
     {
@@ -51,15 +51,15 @@ final class PatientMedicationAllergiesResolver
         }
 
         $r = self::mergeTwoKeys($data, $hasCamel, $hasSnake);
-        if ($r['error'] !== null) {
-            return ['apply' => true, 'error' => $r['error']];
+        if ($r['errorKey'] !== null) {
+            return ['apply' => true, 'errorKey' => $r['errorKey']];
         }
 
         return ['apply' => true, 'value' => $r['value']];
     }
 
     /**
-     * @return array{value: string, error: ?string}
+     * @return array{value: string, errorKey: ?string}
      */
     private static function mergeTwoKeys(array $data, bool $hasCamel, bool $hasSnake): array
     {
@@ -67,17 +67,17 @@ final class PatientMedicationAllergiesResolver
             $v1 = self::normalizeString($data['medicationAllergies'] ?? null);
             $v2 = self::normalizeString($data['medication_allergies'] ?? null);
             if ($v1 !== $v2) {
-                return ['value' => '', 'error' => 'medicationAllergies and medication_allergies must match when both are provided'];
+                return ['value' => '', 'errorKey' => 'PATIENT_ALLERGIES_KEYS_MISMATCH'];
             }
 
-            return ['value' => $v1, 'error' => null];
+            return ['value' => $v1, 'errorKey' => null];
         }
 
         if ($hasCamel) {
-            return ['value' => self::normalizeString($data['medicationAllergies'] ?? null), 'error' => null];
+            return ['value' => self::normalizeString($data['medicationAllergies'] ?? null), 'errorKey' => null];
         }
 
-        return ['value' => self::normalizeString($data['medication_allergies'] ?? null), 'error' => null];
+        return ['value' => self::normalizeString($data['medication_allergies'] ?? null), 'errorKey' => null];
     }
 
     private static function normalizeString(mixed $v): string

--- a/src/Util/PatientProfileImageResolver.php
+++ b/src/Util/PatientProfileImageResolver.php
@@ -29,7 +29,7 @@ final class PatientProfileImageResolver
     }
 
     /**
-     * @return array{ok: true, value: ?string}|array{ok: false, message: string}
+     * @return array{ok: true, value: ?string}|array{ok: false, messageKey: string, messageParams?: array<string, string|int>}
      */
     public static function validateAndNormalize(mixed $value): array
     {
@@ -37,14 +37,18 @@ final class PatientProfileImageResolver
             return ['ok' => true, 'value' => null];
         }
         if (!\is_string($value)) {
-            return ['ok' => false, 'message' => 'profile_image must be a string or null.'];
+            return ['ok' => false, 'messageKey' => 'PATIENT_PROFILE_IMAGE_NOT_STRING'];
         }
         $trimmed = trim($value);
         if (\strlen($trimmed) > self::MAX_LENGTH) {
-            return ['ok' => false, 'message' => 'profile_image payload too large (max 2,000,000 characters).'];
+            return [
+                'ok' => false,
+                'messageKey' => 'PATIENT_PROFILE_IMAGE_TOO_LARGE',
+                'messageParams' => ['%max_chars%' => (string) self::MAX_LENGTH],
+            ];
         }
         if ($trimmed !== '' && !preg_match('#^data:image/[a-zA-Z0-9.+-]+;base64,#', $trimmed)) {
-            return ['ok' => false, 'message' => 'profile_image must be a data URL (data:image/*;base64,...).'];
+            return ['ok' => false, 'messageKey' => 'PATIENT_PROFILE_IMAGE_INVALID_DATA_URL'];
         }
 
         return ['ok' => true, 'value' => $trimmed === '' ? null : $trimmed];

--- a/tests/Controller/Api/ApiAcceptLanguageTest.php
+++ b/tests/Controller/Api/ApiAcceptLanguageTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Controller\Api;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Comprueba que {@see \App\EventSubscriber\ApiLocaleSubscriber} y el dominio de traducción {@code api}
+ * alinean las respuestas JSON con {@code Accept-Language} (como envía el frontend Angular).
+ *
+ * Frontend (repo hermano FalconCare): {@code src/app/interceptors/locale.interceptor.ts},
+ * {@code src/app/services/language.service.ts}, registro en {@code src/app/app.config.ts}.
+ */
+final class ApiAcceptLanguageTest extends WebTestCase
+{
+    /**
+     * @return array{\Symfony\Bundle\FrameworkBundle\KernelBrowser, string}
+     */
+    private static function createAuthenticatedDoctor(): array
+    {
+        $client = static::createClient();
+        $email = 'doc-accept-lang-' . uniqid('', true) . '@falconcare.local';
+        $client->request('POST', '/api/auth/register-doctor', [], [], ['CONTENT_TYPE' => 'application/json'], json_encode([
+            'fullName' => 'Doc Accept Lang',
+            'email' => $email,
+            'password' => 'Doctor123!',
+        ], \JSON_THROW_ON_ERROR));
+        self::assertResponseStatusCodeSame(Response::HTTP_CREATED);
+
+        $client->request('POST', '/api/auth/login', [], [], ['CONTENT_TYPE' => 'application/json'], json_encode([
+            'email' => $email,
+            'password' => 'Doctor123!',
+        ], \JSON_THROW_ON_ERROR));
+        self::assertResponseIsSuccessful();
+        $auth = json_decode((string) $client->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+
+        return [$client, 'Bearer ' . $auth['accessToken']];
+    }
+
+    public function testDocumentsListWithoutFilterLocalizesMessageAndHttpLineByAcceptLanguage(): void
+    {
+        [$client, $bearer] = self::createAuthenticatedDoctor();
+        $authHeaders = ['HTTP_AUTHORIZATION' => $bearer];
+
+        $client->request('GET', '/api/documents', [], [], array_merge($authHeaders, [
+            'HTTP_ACCEPT_LANGUAGE' => 'ca',
+        ]));
+        self::assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+        $ca = json_decode((string) $client->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+        self::assertSame('DOCUMENT_PATIENT_FILTER_REQUIRED', $ca['code']);
+        self::assertStringContainsString('Indiqueu filtre de pacient', (string) $ca['message']);
+        self::assertSame('Sol·licitud incorrecta', $ca['error']);
+
+        $client->request('GET', '/api/documents', [], [], array_merge($authHeaders, [
+            'HTTP_ACCEPT_LANGUAGE' => 'es',
+        ]));
+        self::assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+        $es = json_decode((string) $client->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+        self::assertSame('DOCUMENT_PATIENT_FILTER_REQUIRED', $es['code']);
+        self::assertStringContainsString('Indique filtro de paciente', (string) $es['message']);
+        self::assertSame('Solicitud incorrecta', $es['error']);
+
+        $client->request('GET', '/api/documents', [], [], array_merge($authHeaders, [
+            'HTTP_ACCEPT_LANGUAGE' => 'en',
+        ]));
+        self::assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+        $en = json_decode((string) $client->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+        self::assertStringContainsString('Provide patientId', (string) $en['message']);
+        self::assertSame('Bad Request', $en['error']);
+
+        $client->request('GET', '/api/documents', [], [], array_merge($authHeaders, [
+            'HTTP_ACCEPT_LANGUAGE' => 'fr',
+        ]));
+        self::assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+        $fr = json_decode((string) $client->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+        self::assertStringContainsString('Indiquez un filtre patient', (string) $fr['message']);
+        self::assertSame('Requête incorrecte', $fr['error']);
+
+        self::assertNotSame($ca['message'], $es['message']);
+        self::assertNotSame($es['message'], $en['message']);
+        self::assertNotSame($en['message'], $fr['message']);
+    }
+
+    public function testLocaleQueryParameterOverridesAcceptLanguage(): void
+    {
+        [$client, $bearer] = self::createAuthenticatedDoctor();
+        $authHeaders = ['HTTP_AUTHORIZATION' => $bearer];
+
+        $client->request('GET', '/api/documents?locale=fr', [], [], array_merge($authHeaders, [
+            'HTTP_ACCEPT_LANGUAGE' => 'ca',
+        ]));
+        self::assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+        $payload = json_decode((string) $client->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+        self::assertStringContainsString('Indiquez un filtre patient', (string) $payload['message']);
+        self::assertSame('Requête incorrecte', $payload['error']);
+    }
+}

--- a/tests/Controller/Api/AppointmentsApiTest.php
+++ b/tests/Controller/Api/AppointmentsApiTest.php
@@ -170,11 +170,84 @@ final class AppointmentsApiTest extends WebTestCase
             }
         }
 
-        self::fail('Debe existir al menos un Patient#1..#10 sin lastOdontogramId para probar primera visita.');
+        return self::persistTestPatientWithoutOdontogram($em);
     }
 
-    private static function getExistingTreatmentForPatient(Patient $patient): ?Treatment
+    /**
+     * Paciente nuevo sin lastOdontogramId (BBDD reales / Neon pueden tener ya odontograma en todos los fixtures 1-10).
+     */
+    private static function persistTestPatientWithoutOdontogram(EntityManagerInterface $em): Patient
     {
+        $suffix = strtoupper(bin2hex(random_bytes(5)));
+        $p = new Patient();
+        $p->setIdentityDocument('E2E-NOOD-'.$suffix);
+        $p->setFirstName('Test');
+        $p->setLastName('PrimeraVisita');
+        $p->setPhone('600000001');
+        $p->setEmail('e2e-primera-'.$suffix.'@test.local');
+        $p->setAddress('Adreça test');
+        $p->setConsultationReason('Motiu');
+        $p->setFamilyHistory('N/A');
+        $p->setHealthStatus('Bo');
+        $p->setLifestyleHabits('N/A');
+        $p->setMedicationAllergies('Cap coneguda');
+        $p->setRegistrationDate(new \DateTimeImmutable());
+        $em->persist($p);
+        $em->flush();
+
+        return $p;
+    }
+
+    /**
+     * Paciente con id en 1..10 que tenga al menos una cita con tratamiento (datos típicos de fixtures).
+     *
+     * @param list<int>|null $allowedIds restringe candidatos (p. ej. [1, 2, …, 10])
+     */
+    private static function getPatientWithExistingTreatment(
+        EntityManagerInterface $em,
+        ?Patient $exclude = null,
+        ?array $allowedIds = null,
+    ): Patient {
+        $ids = $allowedIds ?? range(1, 10);
+        $start = random_int(0, max(0, \count($ids) - 1));
+        $orderedIds = array_merge(\array_slice($ids, $start), \array_slice($ids, 0, $start));
+
+        foreach ($orderedIds as $id) {
+            if ($exclude !== null && (int) $id === (int) $exclude->getId()) {
+                continue;
+            }
+            $p = $em->find(Patient::class, $id);
+            if (!$p instanceof Patient) {
+                continue;
+            }
+            if (self::getExistingTreatmentForPatient($em, $p) instanceof Treatment) {
+                return $p;
+            }
+        }
+
+        self::fail('Se necesita al menos un paciente con cita y tratamiento en la BBDD de test (fixtures o ids 1–10).');
+    }
+
+    private static function getExistingTreatmentForPatient(EntityManagerInterface $em, Patient $patient): ?Treatment
+    {
+        $pid = $patient->getId();
+        if ($pid === null) {
+            return null;
+        }
+
+        $fromDb = $em->createQueryBuilder()
+            ->select('t')
+            ->from(Treatment::class, 't')
+            ->innerJoin(Appointment::class, 'a', 'WITH', 'a.treatment = t AND IDENTITY(a.patient) = :pid')
+            ->setParameter('pid', $pid)
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        if ($fromDb instanceof Treatment) {
+            return $fromDb;
+        }
+
         foreach ($patient->getAppointments() as $appointment) {
             $treatment = $appointment->getTreatment();
             if ($treatment instanceof Treatment) {
@@ -240,8 +313,8 @@ final class AppointmentsApiTest extends WebTestCase
         $box = self::getRandomBox($em);
 
         $doctor = self::getDoctorOne($em);
-        $patient = self::getRandomPatientWithoutLastOdontogram($em);
-        $treatment = self::getExistingTreatmentForPatient($patient);
+        $patient = self::getPatientOne($em);
+        $treatment = self::getExistingTreatmentForPatient($em, $patient);
 
         $appointment = new Appointment();
         $visitDate = self::uniqueVisitDate('READ'.strtoupper(bin2hex(random_bytes(4))));
@@ -302,7 +375,7 @@ final class AppointmentsApiTest extends WebTestCase
         $box = self::getRandomBox($em);
 
         $doctor = self::getDoctorOne($em);
-        $patient = self::getPatientOne($em);
+        $patient = self::getRandomPatientWithoutLastOdontogram($em);
 
         self::assertNull($patient->getLastOdontogramId());
 
@@ -365,7 +438,13 @@ final class AppointmentsApiTest extends WebTestCase
         $existingAppointment = $fixture['appointment'];
         $patient = $fixture['patient'];
 
+        /** @var Box $boxOne */
+        $boxOne = self::getRandomExistingEntityById($em, Box::class, [1], 'Box');
+        $existingAppointment->setBox($boxOne);
+        $em->flush();
+
         $otherBox = self::getBoxTwo($em);
+        self::assertNotSame($boxOne->getId(), $otherBox->getId(), 'El test exige cita existente en caja 1 y nueva cita en caja 2.');
 
         $headers = self::getAuthHeadersFor($client, $adminEmail, 'secret123');
 
@@ -579,11 +658,11 @@ final class AppointmentsApiTest extends WebTestCase
 
         $doctor1 = self::getDoctorOne($em);
         $doctor2 = self::getOtherDoctor($em, $doctor1);
-        $patient1 = self::getPatientOne($em);
-        $patient2 = self::getOtherPatient($em, $patient1);
+        $patient1 = self::getPatientWithExistingTreatment($em);
+        $patient2 = self::getPatientWithExistingTreatment($em, $patient1);
 
-        $treatment1 = self::getExistingTreatmentForPatient($patient1);
-        $treatment2 = self::getExistingTreatmentForPatient($patient2);
+        $treatment1 = self::getExistingTreatmentForPatient($em, $patient1);
+        $treatment2 = self::getExistingTreatmentForPatient($em, $patient2);
         self::assertInstanceOf(Treatment::class, $treatment1, 'El paciente inicial debe tener un tratamiento existente en la BBDD de test.');
         self::assertInstanceOf(Treatment::class, $treatment2, 'El paciente destino debe tener un tratamiento existente en la BBDD de test.');
 

--- a/tests/Controller/Api/PatientProfileImageApiTest.php
+++ b/tests/Controller/Api/PatientProfileImageApiTest.php
@@ -39,6 +39,7 @@ final class PatientProfileImageApiTest extends WebTestCase
         return [
             'CONTENT_TYPE' => 'application/json',
             'HTTP_AUTHORIZATION' => 'Bearer ' . $token,
+            'HTTP_ACCEPT_LANGUAGE' => 'es',
         ];
     }
 
@@ -198,6 +199,7 @@ final class PatientProfileImageApiTest extends WebTestCase
         $userHeaders = [
             'CONTENT_TYPE' => 'application/json',
             'HTTP_AUTHORIZATION' => 'Bearer ' . $login['accessToken'],
+            'HTTP_ACCEPT_LANGUAGE' => 'es',
         ];
 
         $client->request('PUT', '/api/patients/' . $patient['id'], [], [], $userHeaders, json_encode([
@@ -205,7 +207,7 @@ final class PatientProfileImageApiTest extends WebTestCase
         ], \JSON_THROW_ON_ERROR));
         self::assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
         $err = json_decode((string) $client->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
-        self::assertSame('Forbidden', $err['error']);
+        self::assertSame('Prohibido', $err['error']);
     }
 
     public function testMedicationAllergiesStillWorksOnPut(): void

--- a/tests/Controller/Api/UserControllerTest.php
+++ b/tests/Controller/Api/UserControllerTest.php
@@ -44,7 +44,10 @@ final class UserControllerTest extends WebTestCase
      */
     private static function getAuthHeadersFor(\Symfony\Bundle\FrameworkBundle\KernelBrowser $client, string $email, string $password): array
     {
-        $client->request('POST', '/api/auth/login', [], [], ['CONTENT_TYPE' => 'application/json'], json_encode([
+        $client->request('POST', '/api/auth/login', [], [], [
+            'CONTENT_TYPE' => 'application/json',
+            'HTTP_ACCEPT_LANGUAGE' => 'es',
+        ], json_encode([
             'email' => $email,
             'password' => $password,
         ], \JSON_THROW_ON_ERROR));
@@ -56,6 +59,7 @@ final class UserControllerTest extends WebTestCase
         return [
             'CONTENT_TYPE' => 'application/json',
             'HTTP_AUTHORIZATION' => 'Bearer ' . $payload['accessToken'],
+            'HTTP_ACCEPT_LANGUAGE' => 'es',
         ];
     }
 
@@ -127,7 +131,7 @@ final class UserControllerTest extends WebTestCase
 
         self::assertResponseStatusCodeSame(403);
         $payload = json_decode((string) $client->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
-        self::assertSame('Forbidden', $payload['error']);
+        self::assertSame('Prohibido', $payload['error']);
     }
 
     public function testUpdateOwnUserProfileImageTooLargeReturns400(): void
@@ -146,7 +150,7 @@ final class UserControllerTest extends WebTestCase
 
         self::assertResponseStatusCodeSame(400);
         $payload = json_decode((string) $client->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
-        self::assertSame('Validation failed', $payload['error']);
+        self::assertSame('Error de validación.', $payload['error']);
     }
 
     public function testUpdateOwnUserProfileImageNullClearsColumn(): void
@@ -215,6 +219,6 @@ final class UserControllerTest extends WebTestCase
 
         self::assertResponseStatusCodeSame(400);
         $payload = json_decode((string) $client->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
-        self::assertSame('Validation failed', $payload['error']);
+        self::assertSame('Error de validación.', $payload['error']);
     }
 }

--- a/translations/api.ca.yaml
+++ b/translations/api.ca.yaml
@@ -1,0 +1,95 @@
+http:
+    '400': Sol·licitud incorrecta
+    '401': No autoritzat
+    '403': Accés denegat
+    '404': No trobat
+    '409': Conflicte
+    '413': Càrrega massa gran
+    '422': Contingut no processable
+    '500': Error intern del servidor
+
+error:
+    DOCUMENT_PATIENT_FILTER_REQUIRED: 'Indiqueu filtre de pacient (patientId, patient.id, patient_id, patient[id] o patient com a IRI). Cal acotar per pacient; l''accés sense filtre no està permès.'
+    PATIENT_NOT_FOUND: Pacient no trobat.
+    DATE_REQUIRED: El paràmetre date és obligatori.
+    INVALID_DATE: 'Format de data no vàlid. Useu Y-m-d.'
+    DOCUMENT_PATIENT_ID_REQUIRED: El paràmetre de consulta patientId és obligatori i ha de coincidir amb el pacient del document.
+    DOCUMENT_FILE_NOT_FOUND: Fitxer no trobat al servidor.
+    DOCUMENT_FILE_REQUIRED: No s''ha enviat cap fitxer.
+    DOCUMENT_FILE_TOO_LARGE: El fitxer supera el límit de mida permès.
+    DOCUMENT_FILE_TOO_LARGE_BYTES: 'El fitxer pujat supera el màxim configurat de %max_bytes% bytes.'
+    DOCUMENT_FILE_UPLOAD_ERROR: S''ha detectat un error en la pujada.
+    DOCUMENT_PATIENT_REQUIRED: 'El camp patient és obligatori i ha de ser la IRI absoluta del pacient.'
+    DOCUMENT_PATIENT_ABSOLUTE_IRI_REQUIRED: 'El camp patient ha de ser exactament "%base_url%/api/patients/{id}" (IRI absoluta que coincideixi amb API_BASE_URL).'
+    DOCUMENT_FILE_EMPTY: El fitxer pujat està buit.
+    DOCUMENT_FILE_EXTENSION_NOT_ALLOWED: L''extensió del fitxer no està permesa.
+    DOCUMENT_FILE_MIME_NOT_ALLOWED: 'El tipus MIME del fitxer (%mime_type%) no està permès.'
+    DOCUMENT_FILE_MIME_EXTENSION_MISMATCH: 'El tipus MIME detectat (%mime_type%) no coincideix amb l''extensió del fitxer (s''esperava %expected_mime%).'
+    DOCUMENT_TYPE_NOT_ALLOWED: 'El tipus declarat (%type%) no està permès.'
+    DOCUMENT_TYPE_FILE_MISMATCH: 'El tipus declarat (%type%) no coincideix amb el fitxer pujat (s''esperava %expected_type%).'
+    DOCUMENT_FILE_STORE_FAILED: No s''ha pogut desar el fitxer al servidor.
+    INVALID_JSON: Cos JSON no vàlid.
+    DOCUMENT_DESCRIPTION_REQUIRED: El camp description és obligatori per actualitzar les notes clíniques.
+    DOCUMENT_DESCRIPTION_INVALID: El camp description ha de ser una cadena o null.
+    DOCUMENT_ACCESS_FORBIDDEN: No teniu permís per accedir als documents del pacient.
+    DOCUMENT_NOT_FOUND: Document no trobat.
+    DOCUMENT_PATIENT_MISMATCH: El document no pertany al pacient indicat.
+
+    AUTH_VALIDATION_FAILED: 'Error de validació.'
+    AUTH_FIELD_BLANK: 'Aquest valor no ha d''estar buit.'
+    AUTH_INVALID_CREDENTIALS: 'Credencials no vàlides.'
+    AUTH_UNAUTHORIZED: No autoritzat.
+    AUTH_REGISTER_FIELDS_REQUIRED: 'Cal fullName, email i password.'
+    AUTH_PASSWORD_MIN_LENGTH: 'La contrasenya ha de tenir com a mínim 8 caràcters.'
+    EMAIL_ALREADY_REGISTERED: 'El correu electrònic ja està registrat.'
+    AUTH_FULL_NAME_REQUIRES_SURNAME: 'El nom complet ha d''incloure nom i cognoms.'
+
+    USER_ACCESS_PROFILE_FORBIDDEN: 'Només podeu accedir al vostre perfil d''usuari.'
+    USER_UPDATE_PROFILE_FORBIDDEN: 'Només podeu actualitzar el vostre perfil d''usuari.'
+    USER_DELETE_ADMIN_ONLY: 'Només els administradors poden eliminar usuaris.'
+
+    PATIENT_DOCUMENTS_LIST_FORBIDDEN: 'No teniu permís per llistar els documents del pacient.'
+    PATIENT_APPOINTMENTS_LIST_FORBIDDEN: 'No teniu permís per llistar les cites del pacient.'
+    PATIENT_UPDATE_FORBIDDEN: 'No teniu permís per actualitzar pacients.'
+    PATIENTS_NONE_BY_IDENTITY: 'No s''han trobat pacients.'
+    PATIENT_CREATE_MISSING_FIELDS: 'Falten camps obligatoris.'
+    PATIENT_CREATE_ALREADY_EXISTS: 'El pacient ja existeix.'
+    PATIENT_INVALID_REGISTRATION_DATE: 'Format de registrationDate no vàlid.'
+
+    PATIENT_ALLERGIES_REQUIRED: 'Cal la informació d''al·lèrgies a medicaments (medicationAllergies o medication_allergies).'
+    PATIENT_ALLERGIES_KEYS_MISMATCH: 'medicationAllergies i medication_allergies han de coincidir si s''envien tots dos.'
+    PATIENT_PROFILE_IMAGE_NOT_STRING: 'profile_image ha de ser una cadena o null.'
+    PATIENT_PROFILE_IMAGE_TOO_LARGE: 'El contingut de profile_image és massa gran (màxim %max_chars% caràcters).'
+    PATIENT_PROFILE_IMAGE_INVALID_DATA_URL: 'profile_image ha de ser una data URL (data:image/*;base64,...).'
+    ODO_SYNC_ENTRIES_INVALID: 'Entrades de sincronització no vàlides: %reason%'
+
+    APPOINTMENT_DOCTOR_SLOT_CONFLICT: 'El metge ja té una cita en aquest horari.'
+
+    TREATMENT_INVALID_JSON: 'Cos de la petició no vàlid.'
+    TREATMENT_CREATED_LINKED: 'Tractament creat i vinculat a la cita correctament.'
+    TREATMENT_NOT_FOUND: 'Tractament no trobat.'
+    TREATMENT_UPDATED_OK: 'Tractament actualitzat correctament.'
+    TREATMENT_DELETED_OK: 'Tractament eliminat correctament.'
+    TREATMENT_ALREADY_FINISHED_OR_MISSING: 'Tractament no trobat o ja finalitzat.'
+    TREATMENT_FINISHED_OK: 'Tractament marcat com a finalitzat.'
+
+    ODO_PATHOLOGY_ADDED_OK: 'Patologia afegida a la peça correctament.'
+    ODO_TREATMENT_SYNC_OK: 'Tractament creat i visita sincronitzada correctament.'
+    ODO_DETAILS_SYNC_OK: 'Detalls de l''odontograma sincronitzats correctament.'
+    ODO_NOT_FOUND: 'Odontograma no trobat.'
+    ODO_DETAIL_CREATE_FAILED: 'No s''ha pogut crear el detall de l''odontograma.'
+    ODO_TREATMENT_SYNC_FAILED: 'No s''ha pogut crear el tractament ni sincronitzar la visita.'
+    ODO_DETAILS_SYNC_FAILED: 'No s''han pogut sincronitzar els detalls de l''odontograma.'
+    ODO_PATIENT_VISIT_IDS_REQUIRED: 'patient_id i visit_id són obligatoris.'
+    ODO_VISIT_ID_REQUIRED: 'visit_id és obligatori.'
+    ODO_APPOINTMENT_NOT_FOUND: 'Cita no trobada.'
+    ODO_APPOINTMENT_PATIENT_MISMATCH: 'La cita no pertany al pacient de l''odontograma.'
+    ODO_ENTRIES_MUST_BE_ARRAY: 'entries ha de ser un array.'
+    ODO_CREATE_OR_RECOVER_FAILED: 'No s''ha pogut crear ni recuperar l''odontograma.'
+    ODO_PATHOLOGY_TOOTH_REQUIRED: 'pathology_id i tooth_number són obligatoris.'
+    ODO_FACES_MUST_BE_ARRAY: 'faces ha de ser un array.'
+    ODO_PATHOLOGY_NOT_FOUND: 'Patologia no trobada.'
+    ODO_DETAIL_NOT_FOUND: 'Detall de l''odontograma no trobat.'
+    ODO_DETAIL_DELETE_FAILED: 'No s''ha pogut eliminar el detall de l''odontograma.'
+    ODO_CREATED_SUCCESS: 'Odontograma creat correctament.'
+    ODO_REUSED_SUCCESS: 'S''ha reutilitzat l''odontograma obert correctament.'

--- a/translations/api.en.yaml
+++ b/translations/api.en.yaml
@@ -1,0 +1,95 @@
+http:
+    '400': Bad Request
+    '401': Unauthorized
+    '403': Forbidden
+    '404': Not Found
+    '409': Conflict
+    '413': Payload Too Large
+    '422': Unprocessable Content
+    '500': Internal Server Error
+
+error:
+    DOCUMENT_PATIENT_FILTER_REQUIRED: 'Provide patientId, patient.id, patient_id, patient[id], or patient (IRI). A patient filter is required; unfiltered document access is disabled.'
+    PATIENT_NOT_FOUND: Patient not found.
+    DATE_REQUIRED: The date parameter is required.
+    INVALID_DATE: 'Invalid date format. Use Y-m-d.'
+    DOCUMENT_PATIENT_ID_REQUIRED: The patientId query parameter is required and must match the document''s patient.
+    DOCUMENT_FILE_NOT_FOUND: File not found on the server.
+    DOCUMENT_FILE_REQUIRED: No file was provided.
+    DOCUMENT_FILE_TOO_LARGE: The file exceeds the allowed size limit.
+    DOCUMENT_FILE_TOO_LARGE_BYTES: 'The uploaded file exceeds the configured maximum of %max_bytes% bytes.'
+    DOCUMENT_FILE_UPLOAD_ERROR: An upload error was detected.
+    DOCUMENT_PATIENT_REQUIRED: 'The patient field is required and must be the absolute patient IRI.'
+    DOCUMENT_PATIENT_ABSOLUTE_IRI_REQUIRED: 'The patient field must be exactly "%base_url%/api/patients/{id}" (absolute IRI matching API_BASE_URL).'
+    DOCUMENT_FILE_EMPTY: The uploaded file is empty.
+    DOCUMENT_FILE_EXTENSION_NOT_ALLOWED: This file extension is not allowed.
+    DOCUMENT_FILE_MIME_NOT_ALLOWED: 'The file MIME type (%mime_type%) is not allowed.'
+    DOCUMENT_FILE_MIME_EXTENSION_MISMATCH: 'The detected MIME type (%mime_type%) does not match the file extension (expected %expected_mime%).'
+    DOCUMENT_TYPE_NOT_ALLOWED: 'The declared type (%type%) is not allowed.'
+    DOCUMENT_TYPE_FILE_MISMATCH: 'The declared type (%type%) does not match the uploaded file (expected %expected_type%).'
+    DOCUMENT_FILE_STORE_FAILED: The file could not be stored on the server.
+    INVALID_JSON: Invalid JSON body.
+    DOCUMENT_DESCRIPTION_REQUIRED: The description field is required to update clinical notes.
+    DOCUMENT_DESCRIPTION_INVALID: The description field must be a string or null.
+    DOCUMENT_ACCESS_FORBIDDEN: You do not have permission to access patient documents.
+    DOCUMENT_NOT_FOUND: Document not found.
+    DOCUMENT_PATIENT_MISMATCH: The document does not belong to the indicated patient.
+
+    AUTH_VALIDATION_FAILED: 'Validation failed.'
+    AUTH_FIELD_BLANK: 'This value should not be blank.'
+    AUTH_INVALID_CREDENTIALS: 'Invalid credentials.'
+    AUTH_UNAUTHORIZED: Unauthorized.
+    AUTH_REGISTER_FIELDS_REQUIRED: 'fullName, email and password are required.'
+    AUTH_PASSWORD_MIN_LENGTH: 'Password must be at least 8 characters.'
+    EMAIL_ALREADY_REGISTERED: 'Email already registered.'
+    AUTH_FULL_NAME_REQUIRES_SURNAME: 'Full name must include name and surname.'
+
+    USER_ACCESS_PROFILE_FORBIDDEN: 'You can only access your own user profile.'
+    USER_UPDATE_PROFILE_FORBIDDEN: 'You can only update your own user profile.'
+    USER_DELETE_ADMIN_ONLY: 'Only administrators can delete users.'
+
+    PATIENT_DOCUMENTS_LIST_FORBIDDEN: 'You do not have permission to list patient documents.'
+    PATIENT_APPOINTMENTS_LIST_FORBIDDEN: 'You do not have permission to list patient appointments.'
+    PATIENT_UPDATE_FORBIDDEN: 'You do not have permission to update patients.'
+    PATIENTS_NONE_BY_IDENTITY: 'No patients found.'
+    PATIENT_CREATE_MISSING_FIELDS: 'Missing required fields.'
+    PATIENT_CREATE_ALREADY_EXISTS: 'Patient already exists.'
+    PATIENT_INVALID_REGISTRATION_DATE: 'Invalid registrationDate format.'
+
+    PATIENT_ALLERGIES_REQUIRED: 'Medication allergy information is required (medicationAllergies or medication_allergies).'
+    PATIENT_ALLERGIES_KEYS_MISMATCH: 'medicationAllergies and medication_allergies must match when both are provided.'
+    PATIENT_PROFILE_IMAGE_NOT_STRING: 'profile_image must be a string or null.'
+    PATIENT_PROFILE_IMAGE_TOO_LARGE: 'profile_image payload is too large (maximum %max_chars% characters).'
+    PATIENT_PROFILE_IMAGE_INVALID_DATA_URL: 'profile_image must be a data URL (data:image/*;base64,...).'
+    ODO_SYNC_ENTRIES_INVALID: 'Invalid sync entries: %reason%'
+
+    APPOINTMENT_DOCTOR_SLOT_CONFLICT: 'The doctor already has an appointment at that time.'
+
+    TREATMENT_INVALID_JSON: 'Invalid request body.'
+    TREATMENT_CREATED_LINKED: 'Treatment created and linked to the appointment successfully.'
+    TREATMENT_NOT_FOUND: 'Treatment not found.'
+    TREATMENT_UPDATED_OK: 'Treatment updated successfully.'
+    TREATMENT_DELETED_OK: 'Treatment deleted successfully.'
+    TREATMENT_ALREADY_FINISHED_OR_MISSING: 'Treatment not found or already finished.'
+    TREATMENT_FINISHED_OK: 'Treatment marked as finished.'
+
+    ODO_PATHOLOGY_ADDED_OK: 'Pathology added to tooth successfully.'
+    ODO_TREATMENT_SYNC_OK: 'Treatment created and visit synchronized successfully.'
+    ODO_DETAILS_SYNC_OK: 'Odontogram details synchronized successfully.'
+    ODO_NOT_FOUND: 'Odontogram not found.'
+    ODO_DETAIL_CREATE_FAILED: 'Could not create the odontogram detail.'
+    ODO_TREATMENT_SYNC_FAILED: 'Could not create the treatment and sync the visit.'
+    ODO_DETAILS_SYNC_FAILED: 'Could not synchronize the odontogram details.'
+    ODO_PATIENT_VISIT_IDS_REQUIRED: 'patient_id and visit_id are required.'
+    ODO_VISIT_ID_REQUIRED: 'visit_id is required.'
+    ODO_APPOINTMENT_NOT_FOUND: 'Appointment not found.'
+    ODO_APPOINTMENT_PATIENT_MISMATCH: 'The appointment does not belong to the odontogram patient.'
+    ODO_ENTRIES_MUST_BE_ARRAY: 'entries must be an array.'
+    ODO_CREATE_OR_RECOVER_FAILED: 'Could not create or recover the odontogram.'
+    ODO_PATHOLOGY_TOOTH_REQUIRED: 'pathology_id and tooth_number are required.'
+    ODO_FACES_MUST_BE_ARRAY: 'faces must be an array.'
+    ODO_PATHOLOGY_NOT_FOUND: 'Pathology not found.'
+    ODO_DETAIL_NOT_FOUND: 'Odontogram detail not found.'
+    ODO_DETAIL_DELETE_FAILED: 'Could not delete the odontogram detail.'
+    ODO_CREATED_SUCCESS: 'Odontogram created successfully.'
+    ODO_REUSED_SUCCESS: 'Open odontogram reused successfully.'

--- a/translations/api.es.yaml
+++ b/translations/api.es.yaml
@@ -1,0 +1,95 @@
+http:
+    '400': Solicitud incorrecta
+    '401': No autorizado
+    '403': Prohibido
+    '404': No encontrado
+    '409': Conflicto
+    '413': Carga demasiado grande
+    '422': Contenido no procesable
+    '500': Error interno del servidor
+
+error:
+    DOCUMENT_PATIENT_FILTER_REQUIRED: 'Indique filtro de paciente (patientId, patient.id, patient_id, patient[id] o patient como IRI). Es obligatorio acotar por paciente; el acceso sin filtro no está permitido.'
+    PATIENT_NOT_FOUND: Paciente no encontrado.
+    DATE_REQUIRED: El parámetro date es obligatorio.
+    INVALID_DATE: 'Formato de fecha no válido. Use Y-m-d.'
+    DOCUMENT_PATIENT_ID_REQUIRED: El parámetro de consulta patientId es obligatorio y debe coincidir con el paciente del documento.
+    DOCUMENT_FILE_NOT_FOUND: Archivo no encontrado en el servidor.
+    DOCUMENT_FILE_REQUIRED: No se ha enviado ningún archivo.
+    DOCUMENT_FILE_TOO_LARGE: El archivo supera el límite de tamaño permitido.
+    DOCUMENT_FILE_TOO_LARGE_BYTES: 'El archivo subido supera el máximo configurado de %max_bytes% bytes.'
+    DOCUMENT_FILE_UPLOAD_ERROR: Se ha detectado un error en la subida.
+    DOCUMENT_PATIENT_REQUIRED: 'El campo patient es obligatorio y debe ser la IRI absoluta del paciente.'
+    DOCUMENT_PATIENT_ABSOLUTE_IRI_REQUIRED: 'El campo patient debe ser exactamente "%base_url%/api/patients/{id}" (IRI absoluta que coincida con API_BASE_URL).'
+    DOCUMENT_FILE_EMPTY: El archivo subido está vacío.
+    DOCUMENT_FILE_EXTENSION_NOT_ALLOWED: La extensión del archivo no está permitida.
+    DOCUMENT_FILE_MIME_NOT_ALLOWED: 'El tipo MIME del archivo (%mime_type%) no está permitido.'
+    DOCUMENT_FILE_MIME_EXTENSION_MISMATCH: 'El tipo MIME detectado (%mime_type%) no coincide con la extensión del archivo (se esperaba %expected_mime%).'
+    DOCUMENT_TYPE_NOT_ALLOWED: 'El tipo declarado (%type%) no está permitido.'
+    DOCUMENT_TYPE_FILE_MISMATCH: 'El tipo declarado (%type%) no coincide con el archivo subido (se esperaba %expected_type%).'
+    DOCUMENT_FILE_STORE_FAILED: No se ha podido guardar el archivo en el servidor.
+    INVALID_JSON: Cuerpo JSON no válido.
+    DOCUMENT_DESCRIPTION_REQUIRED: El campo description es obligatorio para actualizar las notas clínicas.
+    DOCUMENT_DESCRIPTION_INVALID: El campo description debe ser una cadena o null.
+    DOCUMENT_ACCESS_FORBIDDEN: No tiene permiso para acceder a los documentos del paciente.
+    DOCUMENT_NOT_FOUND: Documento no encontrado.
+    DOCUMENT_PATIENT_MISMATCH: El documento no pertenece al paciente indicado.
+
+    AUTH_VALIDATION_FAILED: 'Error de validación.'
+    AUTH_FIELD_BLANK: 'Este valor no debe estar vacío.'
+    AUTH_INVALID_CREDENTIALS: 'Credenciales no válidas.'
+    AUTH_UNAUTHORIZED: No autorizado.
+    AUTH_REGISTER_FIELDS_REQUIRED: 'Son obligatorios fullName, email y password.'
+    AUTH_PASSWORD_MIN_LENGTH: 'La contraseña debe tener al menos 8 caracteres.'
+    EMAIL_ALREADY_REGISTERED: 'El correo electrónico ya está registrado.'
+    AUTH_FULL_NAME_REQUIRES_SURNAME: 'El nombre completo debe incluir nombre y apellidos.'
+
+    USER_ACCESS_PROFILE_FORBIDDEN: 'Solo puede acceder a su propio perfil de usuario.'
+    USER_UPDATE_PROFILE_FORBIDDEN: 'Solo puede actualizar su propio perfil de usuario.'
+    USER_DELETE_ADMIN_ONLY: 'Solo los administradores pueden eliminar usuarios.'
+
+    PATIENT_DOCUMENTS_LIST_FORBIDDEN: 'No tiene permiso para listar los documentos del paciente.'
+    PATIENT_APPOINTMENTS_LIST_FORBIDDEN: 'No tiene permiso para listar las citas del paciente.'
+    PATIENT_UPDATE_FORBIDDEN: 'No tiene permiso para actualizar pacientes.'
+    PATIENTS_NONE_BY_IDENTITY: 'No se han encontrado pacientes.'
+    PATIENT_CREATE_MISSING_FIELDS: 'Faltan campos obligatorios.'
+    PATIENT_CREATE_ALREADY_EXISTS: 'El paciente ya existe.'
+    PATIENT_INVALID_REGISTRATION_DATE: 'Formato de registrationDate no válido.'
+
+    PATIENT_ALLERGIES_REQUIRED: 'La información de alergias a medicamentos es obligatoria (medicationAllergies o medication_allergies).'
+    PATIENT_ALLERGIES_KEYS_MISMATCH: 'medicationAllergies y medication_allergies deben coincidir si se envían ambos.'
+    PATIENT_PROFILE_IMAGE_NOT_STRING: 'profile_image debe ser una cadena o null.'
+    PATIENT_PROFILE_IMAGE_TOO_LARGE: 'El contenido de profile_image es demasiado grande (máximo %max_chars% caracteres).'
+    PATIENT_PROFILE_IMAGE_INVALID_DATA_URL: 'profile_image debe ser una data URL (data:image/*;base64,...).'
+    ODO_SYNC_ENTRIES_INVALID: 'Entradas de sincronización no válidas: %reason%'
+
+    APPOINTMENT_DOCTOR_SLOT_CONFLICT: 'El doctor ya tiene una cita en ese horario.'
+
+    TREATMENT_INVALID_JSON: 'Cuerpo de la petición no válido.'
+    TREATMENT_CREATED_LINKED: 'Tratamiento creado y vinculado a la cita correctamente.'
+    TREATMENT_NOT_FOUND: 'Tratamiento no encontrado.'
+    TREATMENT_UPDATED_OK: 'Tratamiento actualizado correctamente.'
+    TREATMENT_DELETED_OK: 'Tratamiento eliminado correctamente.'
+    TREATMENT_ALREADY_FINISHED_OR_MISSING: 'Tratamiento no encontrado o ya finalizado.'
+    TREATMENT_FINISHED_OK: 'Tratamiento marcado como finalizado.'
+
+    ODO_PATHOLOGY_ADDED_OK: 'Patología añadida al diente correctamente.'
+    ODO_TREATMENT_SYNC_OK: 'Tratamiento creado y visita sincronizada correctamente.'
+    ODO_DETAILS_SYNC_OK: 'Detalles del odontograma sincronizados correctamente.'
+    ODO_NOT_FOUND: 'Odontograma no encontrado.'
+    ODO_DETAIL_CREATE_FAILED: 'No se ha podido crear el detalle del odontograma.'
+    ODO_TREATMENT_SYNC_FAILED: 'No se ha podido crear el tratamiento ni sincronizar la visita.'
+    ODO_DETAILS_SYNC_FAILED: 'No se han podido sincronizar los detalles del odontograma.'
+    ODO_PATIENT_VISIT_IDS_REQUIRED: 'patient_id y visit_id son obligatorios.'
+    ODO_VISIT_ID_REQUIRED: 'visit_id es obligatorio.'
+    ODO_APPOINTMENT_NOT_FOUND: 'Cita no encontrada.'
+    ODO_APPOINTMENT_PATIENT_MISMATCH: 'La cita no pertenece al paciente del odontograma.'
+    ODO_ENTRIES_MUST_BE_ARRAY: 'entries debe ser un array.'
+    ODO_CREATE_OR_RECOVER_FAILED: 'No se ha podido crear ni recuperar el odontograma.'
+    ODO_PATHOLOGY_TOOTH_REQUIRED: 'pathology_id y tooth_number son obligatorios.'
+    ODO_FACES_MUST_BE_ARRAY: 'faces debe ser un array.'
+    ODO_PATHOLOGY_NOT_FOUND: 'Patología no encontrada.'
+    ODO_DETAIL_NOT_FOUND: 'Detalle del odontograma no encontrado.'
+    ODO_DETAIL_DELETE_FAILED: 'No se ha podido eliminar el detalle del odontograma.'
+    ODO_CREATED_SUCCESS: 'Odontograma creado correctamente.'
+    ODO_REUSED_SUCCESS: 'Se ha reutilizado el odontograma abierto correctamente.'

--- a/translations/api.fr.yaml
+++ b/translations/api.fr.yaml
@@ -1,0 +1,95 @@
+http:
+    '400': Requête incorrecte
+    '401': Non autorisé
+    '403': Interdit
+    '404': Non trouvé
+    '409': Conflit
+    '413': Charge utile trop volumineuse
+    '422': Contenu non traitable
+    '500': Erreur interne du serveur
+
+error:
+    DOCUMENT_PATIENT_FILTER_REQUIRED: 'Indiquez un filtre patient (patientId, patient.id, patient_id, patient[id] ou patient en IRI). Un filtre patient est obligatoire ; l''accès sans filtre n''est pas autorisé.'
+    PATIENT_NOT_FOUND: Patient introuvable.
+    DATE_REQUIRED: Le paramètre date est obligatoire.
+    INVALID_DATE: 'Format de date invalide. Utilisez Y-m-d.'
+    DOCUMENT_PATIENT_ID_REQUIRED: Le paramètre de requête patientId est obligatoire et doit correspondre au patient du document.
+    DOCUMENT_FILE_NOT_FOUND: Fichier introuvable sur le serveur.
+    DOCUMENT_FILE_REQUIRED: Aucun fichier n''a été fourni.
+    DOCUMENT_FILE_TOO_LARGE: Le fichier dépasse la taille maximale autorisée.
+    DOCUMENT_FILE_TOO_LARGE_BYTES: 'Le fichier téléversé dépasse le maximum configuré de %max_bytes% octets.'
+    DOCUMENT_FILE_UPLOAD_ERROR: Une erreur de téléversement a été détectée.
+    DOCUMENT_PATIENT_REQUIRED: 'Le champ patient est obligatoire et doit être l''IRI absolue du patient.'
+    DOCUMENT_PATIENT_ABSOLUTE_IRI_REQUIRED: 'Le champ patient doit être exactement "%base_url%/api/patients/{id}" (IRI absolue correspondant à API_BASE_URL).'
+    DOCUMENT_FILE_EMPTY: Le fichier téléversé est vide.
+    DOCUMENT_FILE_EXTENSION_NOT_ALLOWED: Cette extension de fichier n''est pas autorisée.
+    DOCUMENT_FILE_MIME_NOT_ALLOWED: 'Le type MIME du fichier (%mime_type%) n''est pas autorisé.'
+    DOCUMENT_FILE_MIME_EXTENSION_MISMATCH: 'Le type MIME détecté (%mime_type%) ne correspond pas à l''extension du fichier (attendu %expected_mime%).'
+    DOCUMENT_TYPE_NOT_ALLOWED: 'Le type déclaré (%type%) n''est pas autorisé.'
+    DOCUMENT_TYPE_FILE_MISMATCH: 'Le type déclaré (%type%) ne correspond pas au fichier téléversé (attendu %expected_type%).'
+    DOCUMENT_FILE_STORE_FAILED: Le fichier n''a pas pu être enregistré sur le serveur.
+    INVALID_JSON: Corps JSON invalide.
+    DOCUMENT_DESCRIPTION_REQUIRED: Le champ description est obligatoire pour mettre à jour les notes cliniques.
+    DOCUMENT_DESCRIPTION_INVALID: Le champ description doit être une chaîne ou null.
+    DOCUMENT_ACCESS_FORBIDDEN: Vous n''avez pas la permission d''accéder aux documents du patient.
+    DOCUMENT_NOT_FOUND: Document introuvable.
+    DOCUMENT_PATIENT_MISMATCH: Le document n''appartient pas au patient indiqué.
+
+    AUTH_VALIDATION_FAILED: 'Échec de la validation.'
+    AUTH_FIELD_BLANK: 'Cette valeur ne doit pas être vide.'
+    AUTH_INVALID_CREDENTIALS: 'Identifiants invalides.'
+    AUTH_UNAUTHORIZED: Non autorisé.
+    AUTH_REGISTER_FIELDS_REQUIRED: 'Les champs fullName, email et password sont obligatoires.'
+    AUTH_PASSWORD_MIN_LENGTH: 'Le mot de passe doit contenir au moins 8 caractères.'
+    EMAIL_ALREADY_REGISTERED: 'Cette adresse e-mail est déjà enregistrée.'
+    AUTH_FULL_NAME_REQUIRES_SURNAME: 'Le nom complet doit inclure le prénom et le nom.'
+
+    USER_ACCESS_PROFILE_FORBIDDEN: 'Vous ne pouvez accéder qu''à votre propre profil utilisateur.'
+    USER_UPDATE_PROFILE_FORBIDDEN: 'Vous ne pouvez mettre à jour que votre propre profil utilisateur.'
+    USER_DELETE_ADMIN_ONLY: 'Seuls les administrateurs peuvent supprimer des utilisateurs.'
+
+    PATIENT_DOCUMENTS_LIST_FORBIDDEN: 'Vous n''avez pas la permission de lister les documents du patient.'
+    PATIENT_APPOINTMENTS_LIST_FORBIDDEN: 'Vous n''avez pas la permission de lister les rendez-vous du patient.'
+    PATIENT_UPDATE_FORBIDDEN: 'Vous n''avez pas la permission de mettre à jour les patients.'
+    PATIENTS_NONE_BY_IDENTITY: 'Aucun patient trouvé.'
+    PATIENT_CREATE_MISSING_FIELDS: 'Champs obligatoires manquants.'
+    PATIENT_CREATE_ALREADY_EXISTS: 'Le patient existe déjà.'
+    PATIENT_INVALID_REGISTRATION_DATE: 'Format de registrationDate invalide.'
+
+    PATIENT_ALLERGIES_REQUIRED: 'Les informations sur les allergies médicamenteuses sont obligatoires (medicationAllergies ou medication_allergies).'
+    PATIENT_ALLERGIES_KEYS_MISMATCH: 'medicationAllergies et medication_allergies doivent correspondre si les deux sont fournis.'
+    PATIENT_PROFILE_IMAGE_NOT_STRING: 'profile_image doit être une chaîne ou null.'
+    PATIENT_PROFILE_IMAGE_TOO_LARGE: 'Le contenu de profile_image est trop volumineux (maximum %max_chars% caractères).'
+    PATIENT_PROFILE_IMAGE_INVALID_DATA_URL: 'profile_image doit être une data URL (data:image/*;base64,...).'
+    ODO_SYNC_ENTRIES_INVALID: 'Entrées de synchronisation invalides : %reason%'
+
+    APPOINTMENT_DOCTOR_SLOT_CONFLICT: 'Le médecin a déjà un rendez-vous à cette heure.'
+
+    TREATMENT_INVALID_JSON: 'Corps de requête invalide.'
+    TREATMENT_CREATED_LINKED: 'Traitement créé et lié au rendez-vous avec succès.'
+    TREATMENT_NOT_FOUND: 'Traitement introuvable.'
+    TREATMENT_UPDATED_OK: 'Traitement mis à jour avec succès.'
+    TREATMENT_DELETED_OK: 'Traitement supprimé avec succès.'
+    TREATMENT_ALREADY_FINISHED_OR_MISSING: 'Traitement introuvable ou déjà terminé.'
+    TREATMENT_FINISHED_OK: 'Traitement marqué comme terminé.'
+
+    ODO_PATHOLOGY_ADDED_OK: 'Pathologie ajoutée à la dent avec succès.'
+    ODO_TREATMENT_SYNC_OK: 'Traitement créé et visite synchronisée avec succès.'
+    ODO_DETAILS_SYNC_OK: 'Détails de l''odontogramme synchronisés avec succès.'
+    ODO_NOT_FOUND: 'Odontogramme introuvable.'
+    ODO_DETAIL_CREATE_FAILED: 'Impossible de créer le détail de l''odontogramme.'
+    ODO_TREATMENT_SYNC_FAILED: 'Impossible de créer le traitement et de synchroniser la visite.'
+    ODO_DETAILS_SYNC_FAILED: 'Impossible de synchroniser les détails de l''odontogramme.'
+    ODO_PATIENT_VISIT_IDS_REQUIRED: 'patient_id et visit_id sont obligatoires.'
+    ODO_VISIT_ID_REQUIRED: 'visit_id est obligatoire.'
+    ODO_APPOINTMENT_NOT_FOUND: 'Rendez-vous introuvable.'
+    ODO_APPOINTMENT_PATIENT_MISMATCH: 'Le rendez-vous n''appartient pas au patient de l''odontogramme.'
+    ODO_ENTRIES_MUST_BE_ARRAY: 'entries doit être un tableau.'
+    ODO_CREATE_OR_RECOVER_FAILED: 'Impossible de créer ou de récupérer l''odontogramme.'
+    ODO_PATHOLOGY_TOOTH_REQUIRED: 'pathology_id et tooth_number sont obligatoires.'
+    ODO_FACES_MUST_BE_ARRAY: 'faces doit être un tableau.'
+    ODO_PATHOLOGY_NOT_FOUND: 'Pathologie introuvable.'
+    ODO_DETAIL_NOT_FOUND: 'Détail d''odontogramme introuvable.'
+    ODO_DETAIL_DELETE_FAILED: 'Impossible de supprimer le détail de l''odontogramme.'
+    ODO_CREATED_SUCCESS: 'Odontogramme créé avec succès.'
+    ODO_REUSED_SUCCESS: 'Odontogramme ouvert réutilisé avec succès.'


### PR DESCRIPTION
## Qué hacen los commits que acabo de integrar (i18n de la API)

Estos tres commits cierran el mismo objetivo: **que la API hable el mismo idioma que el usuario** (catalán, castellano, inglés o francés), alineado con el front.

### 1. `feat(i18n): Add API translation files and Symfony translator defaults for four locales`

En pocas palabras: **se añaden los diccionarios de la API y se fija el soporte multiidioma en Symfony.**

- Archivos `translations/api.ca.yaml`, `api.es.yaml`, `api.en.yaml` y `api.fr.yaml`: mismas claves en los cuatro idiomas (mensajes de error, textos de negocio expuestos en JSON, etc.).
- Dominio de traducción **`api`**: en los controladores se usa `trans('...', [], 'api')` para no mezclar con otros bundles.
- Ajuste en `config/packages/translation.yaml` para que el traductor conozca los **fallbacks** y el **locale por defecto** coherente con el proyecto.

### 2. `feat(i18n): Resolve API locale from Accept-Language and optional query override`

Aquí entra el **comportamiento en tiempo de ejecución**: cómo se elige el idioma de cada petición a `/api/…`.

- **`ApiLocaleSubscriber`**: en rutas que empiezan por `/api`, fija el locale del `Request` según:
  - **`?locale=ca|es|en|fr`** (prioridad si viene en la query y es válido), o
  - cabecera **`Accept-Language`** (primer idioma soportado).
- Tras los listeners del núcleo (`LocaleListener` / `LocaleAwareListener`), el subscriber **vuelve a sincronizar el servicio `translator`**, porque si solo cambias el `Request` demasiado tarde, los mensajes seguirían saliendo en el idioma por defecto.
- **Controladores de la API** refactorizados para usar un trait común (`ApiTranslatorTrait`) y mensajes centralizados en YAML en lugar de cadenas sueltas donde aplica.
- **`security.yaml`**: detalle mínimo necesario para que el flujo de seguridad no rompa el contrato de idioma en rutas públicas/protegidas (según lo que ya tengáis configurado).
- **Scripts útiles** (`scripts/check-api-translations.php`, `scripts/verify-api-i18n-parity.php`): comprobar que las cuatro YAML tienen las mismas claves y coherencia básica.
- **Tests**: `ApiAcceptLanguageTest` asegura que, con `Accept-Language` o `?locale=`, las respuestas JSON (y líneas de error HTTP) salen en el idioma esperado; otros tests se adaptan a respuestas traducidas donde haga falta.
- **Citas / listados**: cambios en `AppointmentController`, `AppointmentRepository`, `AppointmentListSerializer` para mantener contratos JSON y mensajes alineados con el nuevo esquema de traducción (según el diff de ese commit).

### 3. `README.md update`

**Documentación**: este archivo resume el proyecto, cómo instalarlo y **qué significa cada uno de los commits anteriores**, para que cualquiera del equipo entienda el alcance sin abrir el diff entero.

---

## Cómo encaja con el front Angular

El front envía **`Accept-Language`** en las peticiones a la API (por ejemplo vía interceptor + servicio de idioma). Los cuatro códigos soportados aquí son **`ca`**, **`es`**, **`en`**, **`fr`**, en línea con **ngx-translate** en `FalconCare`.

| Pieza | Ubicación |
| :---- | :-------- |
| Locale por petición API | `src/EventSubscriber/ApiLocaleSubscriber.php` |
| Traducciones dominio `api` | `translations/api.{ca,es,en,fr}.yaml` |
| Contrato de prueba idioma | `tests/Controller/Api/ApiAcceptLanguageTest.php` |
| Comprobación de claves YAML | `php scripts/check-api-translations.php` |

---

## Requisitos

- **PHP** ≥ 8.2  
- **Composer** 2.x  
- Base de datos compatible con Doctrine (**PostgreSQL** recomendado; en local también puede usarse MySQL/MariaDB con la URL adecuada en `.env`).  
- Extensiones PHP habituales: `ctype`, `iconv`, `pdo_*`, `json`, `mbstring`, `openssl`, `xml`, `zip` (y las que requiera tu driver de BD).

---

## Instalación (desde la raíz de este repositorio)

Todas las rutas siguientes asumen que ya estás dentro de la carpeta clonada **`FalconCareSymfony`** (donde está `composer.json` y `bin/console`).

```bash
git clone <url-del-repo>
cd FalconCareSymfony
composer install
```

Crea **`.env.local`** (no se sube a Git) con al menos `DATABASE_URL` y, si hace falta, `APP_SECRET`:

```env
DATABASE_URL="postgresql://usuario:contraseña@host:5432/nombre_bd?serverVersion=16&charset=utf8"
# o, por ejemplo en XAMPP con MySQL:
# DATABASE_URL="mysql://root:@127.0.0.1:3306/falconcare?serverVersion=8.0&charset=utf8mb4"
```

Comprueba conexión y aplica migraciones:

```bash
php bin/console doctrine:query:sql "SELECT 1"
php bin/console doctrine:migrations:migrate --no-interaction
```

(Carga opcional de datos de demo: `php bin/console doctrine:fixtures:load` si usáis `App\DataFixtures`.)

Arranque en desarrollo:

```bash
symfony server:start
# o
php -S 127.0.0.1:8000 -t public
```

La API suele exponerse bajo **`/api/...`** (por ejemplo `http://127.0.0.1:8000/api/health` si tenéis esa ruta).

---

## Estructura general del código

| Área | Contenido breve |
| :--- | :-------------- |
| `src/Entity/` | Modelo de dominio (paciente, cita, documento, etc.) |
| `src/Controller/Api/` | Endpoints REST y respuestas JSON |
| `src/EventSubscriber/` | Incluye `ApiLocaleSubscriber` para idioma en `/api` |
| `translations/` | Mensajes, dominio `api` y otros |
| `tests/Controller/Api/` | Pruebas funcionales de la API (incluye idioma) |

---

## API: documentos y pacientes (resumen)

- **JWT** en rutas protegidas (cabecera `Authorization: Bearer …`).  
- **Pacientes** (`/api/patients`, …): contratos JSON con alias útiles para el front (`medicationAllergies` / `medication_allergies`, etc.).  
- **Documentos** (`/api/documents`, listados por paciente): filtros obligatorios por paciente donde aplica; subidas multipart; errores estructurados; tamaño máximo configurable (`DOCUMENT_MAX_UPLOAD_BYTES` en `.env`).

Detalle de rutas y códigos HTTP: ver controladores en `src/Controller/Api/` y anotaciones OpenAPI donde existan.

---

## Tests y comandos útiles

```bash
composer test
# o
php vendor/bin/phpunit
```

| Comando | Para qué sirve |
| :------ | :------------- |
| `php bin/console lint:container` | Comprueba que el contenedor de servicios compila |
| `php bin/console lint:yaml translations` | Sintaxis de los YAML de traducción |
| `php scripts/check-api-translations.php` | Misma lista de claves en `api.*.yaml` (ca, es, en, fr) |
| `php bin/console cache:clear` | Limpia caché tras cambiar traducciones o config |

---

## Licencia

Proyecto propietario. Ver `composer.json`.